### PR TITLE
[FIX] set Xorg session name in AccountsService configuration

### DIFF
--- a/roles/funcional/tasks/fixes.yml
+++ b/roles/funcional/tasks/fixes.yml
@@ -103,7 +103,7 @@
         create: true
       loop:
         - { key: XSession, value: "{{ xorg_session_name }}" }
-        - { key: Session, value: "" }
+        - { key: Session, value: "{{ xorg_session_name }}" }
         - { key: SessionType, value: "x11" }
       register: xorg_fix_accounts
 


### PR DESCRIPTION
This pull request makes a small but important fix to the `roles/funcional/tasks/fixes.yml` file. The change ensures that the `Session` key is now set to the value of `xorg_session_name` instead of being left empty, which should improve session handling in Xorg configurations.

* Set the `Session` key to `xorg_session_name` instead of an empty string in the session configuration loop (`roles/funcional/tasks/fixes.yml`).