### PR TITLE
chore(lint): resolver warnings de ansible-lint (~180 -> 13)

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -11,12 +11,11 @@ on:
       - main
       - develop
   workflow_dispatch:
-
 jobs:
   lint:
     name: Lint Ansible code
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -24,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Cache Ansible collections
         uses: actions/cache@v4
@@ -83,7 +82,7 @@ jobs:
     name: Test funcional role
     runs-on: ubuntu-latest
     needs: lint
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -91,7 +90,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
@@ -120,8 +119,8 @@ jobs:
             exit 1
           fi
         env:
-          PY_COLORS: '1'
-          ANSIBLE_FORCE_COLOR: '1'
+          PY_COLORS: "1"
+          ANSIBLE_FORCE_COLOR: "1"
 
       - name: Upload test logs on failure
         if: failure()
@@ -137,7 +136,7 @@ jobs:
     name: Test developer role
     runs-on: ubuntu-latest
     needs: lint
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -145,7 +144,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
@@ -174,8 +173,8 @@ jobs:
             exit 1
           fi
         env:
-          PY_COLORS: '1'
-          ANSIBLE_FORCE_COLOR: '1'
+          PY_COLORS: "1"
+          ANSIBLE_FORCE_COLOR: "1"
 
       - name: Upload test logs on failure
         if: failure()
@@ -191,7 +190,7 @@ jobs:
     name: Test sysadmin role
     runs-on: ubuntu-latest
     needs: lint
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -199,7 +198,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
@@ -228,8 +227,8 @@ jobs:
             exit 1
           fi
         env:
-          PY_COLORS: '1'
-          ANSIBLE_FORCE_COLOR: '1'
+          PY_COLORS: "1"
+          ANSIBLE_FORCE_COLOR: "1"
 
       - name: Upload test logs on failure
         if: failure()
@@ -256,33 +255,33 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Role | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
-          
+
           # Funcional
           if [ "${{ needs.test-funcional.result }}" == "success" ]; then
             echo "| funcional | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
           else
             echo "| funcional | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
           fi
-          
+
           # Developer
           if [ "${{ needs.test-developer.result }}" == "success" ]; then
             echo "| developer | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
           else
             echo "| developer | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
           fi
-          
+
           # Sysadmin
           if [ "${{ needs.test-sysadmin.result }}" == "success" ]; then
             echo "| sysadmin | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
           else
             echo "| sysadmin | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
           fi
-          
+
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## Platforms Tested" >> $GITHUB_STEP_SUMMARY
           echo "- 🐧 Debian 13 (Trixie)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          
+
           # Overall status
           if [ "${{ needs.test-funcional.result }}" == "success" ] && \
              [ "${{ needs.test-developer.result }}" == "success" ] && \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 # Pre-commit Configuration for Ansible Notebooks
 # Install: pip install pre-commit && pre-commit install
 
@@ -36,7 +37,7 @@ repos:
         args: [--maxkb=1000]
       - id: check-merge-conflict
       - id: detect-private-key
-        exclude: ^(roles/.*/files/.*\.pub)  # Excluir claves públicas
+        exclude: ^(roles/.*/files/.*\.pub) # Excluir claves públicas
 
   # Markdown Linting
   - repo: https://github.com/igorshubovych/markdownlint-cli

--- a/.yamllint
+++ b/.yamllint
@@ -14,10 +14,20 @@ rules:
   comments:
     min-spaces-from-content: 1
 
-  comments-indentation: {}
+  # Requerido por ansible-lint (modo --fix): debe estar deshabilitado
+  comments-indentation: false
+
+  # Requerido por ansible-lint (modo --fix): máximo 1 espacio dentro de llaves
+  braces:
+    max-spaces-inside: 1
+
+  # Requerido por ansible-lint (modo --fix): prohibir valores octales
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
 
   truthy:
-    allowed-values: ['true', 'false', 'yes', 'no']
+    allowed-values: ["true", "false", "yes", "no"]
     check-keys: false
 
 ignore: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Registro de cambios relevantes del proyecto. Formato basado en [Keep a Changelog
 
 - Alineada la config `.yamllint` con los requisitos de ansible-lint (`comments-indentation`, `braces`, `octal-values`) para habilitar el modo `--fix`
 - Resueltos vía autofix determinístico: `yaml` (formato, 63) y `fqcn` (nombres de módulo completos, 12)
-- `no-handler` (8): las tareas `update_cache when ...changed` se fusionaron como `update_cache: true` en la propia tarea de instalación (preserva orden e idempotencia; elimina los `register` intermedios)
+- `no-handler` (8): las tareas `update_cache when ...changed` se fusionaron en la propia tarea de instalación con `update_cache: true` + `cache_valid_time` condicional (`0` cuando el `.sources` cambió para forzar refresh, `apt_cache_valid_time` si no) — preserva orden e idempotencia y evita refrescar APT en cada corrida sin cambios
 - `no-changed-when` (10) y `name` (1): `changed_when` explícito en comandos imperativos y nombre al play de `assign_laptop.yml`
 - `var-naming` (64): registers y set_facts de los roles renombrados con su prefijo de rol (`funcional_`, `developer_`, `sysadmin_`); en `molecule/` se renombró lo seguro y se anotó con `# noqa` los falsos positivos (override de `ansible_env`, vars cross-role en converge)
 - Restan 13 warnings de menor prioridad (`ignore-errors`, `partial-become`, `risky-shell-pipe`, `command-instead-of-module`) que requieren revisión caso por caso

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Registro de cambios relevantes del proyecto. Formato basado en [Keep a Changelog
 
 ## [2026-06-25]
 
+### Limpieza de warnings de ansible-lint (~180 → 13)
+
+- Alineada la config `.yamllint` con los requisitos de ansible-lint (`comments-indentation`, `braces`, `octal-values`) para habilitar el modo `--fix`
+- Resueltos vía autofix determinístico: `yaml` (formato, 63) y `fqcn` (nombres de módulo completos, 12)
+- `no-handler` (8): las tareas `update_cache when ...changed` se fusionaron como `update_cache: true` en la propia tarea de instalación (preserva orden e idempotencia; elimina los `register` intermedios)
+- `no-changed-when` (10) y `name` (1): `changed_when` explícito en comandos imperativos y nombre al play de `assign_laptop.yml`
+- `var-naming` (64): registers y set_facts de los roles renombrados con su prefijo de rol (`funcional_`, `developer_`, `sysadmin_`); en `molecule/` se renombró lo seguro y se anotó con `# noqa` los falsos positivos (override de `ansible_env`, vars cross-role en converge)
+- Restan 13 warnings de menor prioridad (`ignore-errors`, `partial-become`, `risky-shell-pipe`, `command-instead-of-module`) que requieren revisión caso por caso
+- `ansible-lint local.yml` (lo que corre el CI) pasa limpio a profile `production`
+
 ### Repositorios APT — migración de `apt_repository` al formato deb822 (`.sources`)
 
 - Migrados los 8 repositorios externos del módulo deprecado `ansible.builtin.apt_repository` (será removido en ansible-core 2.25) al formato moderno deb822, en los roles `funcional` (gcloud, kubectl, chrome, adhoccli), `developer` (docker, vscode, github-cli) y `sysadmin` (nordvpn)

--- a/assign_laptop.yml
+++ b/assign_laptop.yml
@@ -1,81 +1,85 @@
-- hosts: all
-  become: yes
+---
+- name: Reasignar laptop a un nuevo usuario
+  hosts: all
+  become: true
 
   vars:
     old_user: adhoc
 
   tasks:
     - name: Terminate user session
-      command: loginctl terminate-user {{ old_user }}
-      ignore_errors: yes
+      ansible.builtin.command: loginctl terminate-user {{ old_user }}
+      changed_when: true
+      ignore_errors: true
 
     - name: Wait for processes to die
-      pause:
+      ansible.builtin.pause:
         seconds: 3
 
     - name: Kill remaining user processes
-      command: pkill -9 -u {{ old_user }}
-      ignore_errors: yes
+      ansible.builtin.command: pkill -9 -u {{ old_user }}
+      changed_when: true
+      ignore_errors: true
 
     - name: Wait for killed processes to exit
-      pause:
+      ansible.builtin.pause:
         seconds: 2
 
     - name: Rename user
-      command: >
+      ansible.builtin.command: >
         usermod -l {{ new_user }}
                 -d /home/{{ new_user }}
                 -m
                 -c "{{ full_name }}"
                 {{ old_user }}
-
+      changed_when: true
     - name: Rename primary group
-      command: groupmod -n {{ new_user }} {{ old_user }}
-
+      ansible.builtin.command: groupmod -n {{ new_user }} {{ old_user }}
+      changed_when: true
     - name: Update primary group assignment
-      command: usermod -g {{ new_user }} {{ new_user }}
-
+      ansible.builtin.command: usermod -g {{ new_user }} {{ new_user }}
+      changed_when: true
     - name: Rename sudoers file if exists
-      command: mv /etc/sudoers.d/{{ old_user }} /etc/sudoers.d/{{ new_user }}
+      ansible.builtin.command: mv /etc/sudoers.d/{{ old_user }} /etc/sudoers.d/{{ new_user }}
       args:
         creates: /etc/sudoers.d/{{ new_user }}
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Update sudoers content
-      replace:
+      ansible.builtin.replace:
         path: /etc/sudoers.d/{{ new_user }}
         regexp: "{{ old_user }}"
         replace: "{{ new_user }}"
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Update GTK bookmarks
       ansible.builtin.replace:
         path: /home/{{ new_user }}/.config/gtk-3.0/bookmarks
         regexp: "/home/{{ old_user }}"
         replace: "/home/{{ new_user }}"
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Set wallpaper URI
-      command: >
+      ansible.builtin.command: >
         sudo -u {{ new_user }} dbus-run-session
         dconf write /org/gnome/desktop/background/picture-uri
         "'file:///home/{{ new_user }}/.wallpaper.png'"
-
+      changed_when: true
     - name: Set wallpaper URI dark
-      command: >
+      ansible.builtin.command: >
         sudo -u {{ new_user }} dbus-run-session
         dconf write /org/gnome/desktop/background/picture-uri-dark
         "'file:///home/{{ new_user }}/.wallpaper.png'"
-
+      changed_when: true
     - name: Set git config for new user
       become_user: "{{ new_user }}"
-      git_config:
+      community.general.git_config:
         name: "{{ item.key }}"
         value: "{{ item.value }}"
         scope: global
       loop:
         - { key: "user.name", value: "{{ full_name }}" }
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Update /etc/hosts hostname
       ansible.builtin.replace:

--- a/local.yml
+++ b/local.yml
@@ -13,7 +13,7 @@
       ansible.builtin.file:
         path: /tmp
         state: directory
-        mode: '1777'
+        mode: "1777"
 
     - name: Actualizar caché de paquetes
       tags: always

--- a/roles/developer/molecule/default/prepare.yml
+++ b/roles/developer/molecule/default/prepare.yml
@@ -18,7 +18,7 @@
         create_home: true
         shell: /bin/bash
 
-    - name: Prepare | Set SUDO_USER environment for testing
+    - name: Prepare | Set SUDO_USER environment for testing  # noqa: var-naming[no-role-prefix]
       ansible.builtin.set_fact:
         ansible_env:
           SUDO_USER: testuser
@@ -27,4 +27,4 @@
       ansible.builtin.file:
         path: /tmp
         state: directory
-        mode: '1777'
+        mode: "1777"

--- a/roles/developer/molecule/default/verify.yml
+++ b/roles/developer/molecule/default/verify.yml
@@ -8,8 +8,8 @@
     - ../../vars.yml
 
   vars:
-    remote_user: "{{ ansible_env.SUDO_USER | default('testuser') }}"
-    docker_group_user: "{{ remote_user }}"
+    developer_remote_user: "{{ ansible_env.SUDO_USER | default('testuser') }}"
+    docker_group_user: "{{ developer_remote_user }}"
     required_package_sets:
       - "{{ developer_packages_base }}"
       - "{{ developer_docker_packages }}"
@@ -45,7 +45,7 @@
 
     - name: Verify | Check VS Code binary is available
       become: true
-      become_user: "{{ remote_user }}"
+      become_user: "{{ developer_remote_user }}"
       ansible.builtin.command: code --version --no-sandbox
       register: developer_code_version
       changed_when: false
@@ -78,7 +78,7 @@
       loop: "{{ linter_packages }}"
 
     - name: Verify | Check git global hooks configuration
-      become_user: "{{ remote_user }}"
+      become_user: "{{ developer_remote_user }}"
       ansible.builtin.command: git config --global core.hooksPath
       register: developer_git_hooks
       changed_when: false
@@ -87,17 +87,17 @@
     - name: Verify | Assert git hooks path configured
       ansible.builtin.assert:
         that:
-          - developer_git_hooks.stdout.strip() == "/home/{{ remote_user }}/.git_hooks"
-        fail_msg: "Expected git hooks path '/home/{{ remote_user }}/.git_hooks', but got '{{ developer_git_hooks.stdout.strip() }}'"
+          - developer_git_hooks.stdout.strip() == "/home/{{ developer_remote_user }}/.git_hooks"
+        fail_msg: "Expected git hooks path '/home/{{ developer_remote_user }}/.git_hooks', but got '{{ developer_git_hooks.stdout.strip() }}'"
 
     - name: Verify | Check dotfiles copied
       ansible.builtin.stat:
         path: "{{ item }}"
       loop:
-        - "/home/{{ remote_user }}/.bash_aliases"
-        - "/home/{{ remote_user }}/.adhoc_bash_ps.sh"
-        - "/home/{{ remote_user }}/.tmux"
-        - "/home/{{ remote_user }}/.prompt_git"
+        - "/home/{{ developer_remote_user }}/.bash_aliases"
+        - "/home/{{ developer_remote_user }}/.adhoc_bash_ps.sh"
+        - "/home/{{ developer_remote_user }}/.tmux"
+        - "/home/{{ developer_remote_user }}/.prompt_git"
       register: developer_dotfiles
 
     - name: Verify | Assert dotfiles exist
@@ -109,7 +109,7 @@
 
     - name: Verify | Check ssh configuration exists
       ansible.builtin.stat:
-        path: "/home/{{ remote_user }}/.ssh/config"
+        path: "/home/{{ developer_remote_user }}/.ssh/config"
       register: developer_ssh_config
 
     - name: Verify | Assert ssh config created

--- a/roles/developer/tasks/code.yml
+++ b/roles/developer/tasks/code.yml
@@ -7,31 +7,31 @@
       ansible.builtin.file:
         path: /etc/apt/keyrings
         state: directory
-        mode: '0755'
+        mode: "0755"
 
     - name: Code | Verificar si la clave GPG ya está instalada
       ansible.builtin.stat:
         path: "{{ developer_external_repos.vscode.keyring_path }}"
-      register: vscode_gpg_key
+      register: developer_vscode_gpg_key
 
     - name: Code | Descargar la clave GPG de Microsoft
       ansible.builtin.get_url:
         url: "{{ developer_external_repos.vscode.gpg_url }}"
         dest: /tmp/microsoft.asc
-        mode: '0644'
-      when: not vscode_gpg_key.stat.exists
+        mode: "0644"
+      when: not developer_vscode_gpg_key.stat.exists
 
     - name: Code | Convertir y guardar la clave GPG
       ansible.builtin.command: >-
         gpg --dearmor -o {{ developer_external_repos.vscode.keyring_path }} /tmp/microsoft.asc
-      when: not vscode_gpg_key.stat.exists
+      when: not developer_vscode_gpg_key.stat.exists
       changed_when: false
 
     - name: Code | Limpiar archivo temporal
       ansible.builtin.file:
         path: /tmp/microsoft.asc
         state: absent
-      when: not vscode_gpg_key.stat.exists
+      when: not developer_vscode_gpg_key.stat.exists
 
     # El paquete 'code' de Microsoft autogestiona su propio archivo de repo
     # (postinst reescribe vscode.sources). Configuramos el repo solo como
@@ -40,13 +40,13 @@
     - name: Code | Verificar si VS Code ya está instalado
       ansible.builtin.stat:
         path: /usr/bin/code
-      register: vscode_installed
+      register: developer_vscode_installed
 
     - name: Code | Eliminar el repositorio legacy en formato .list (migración a deb822)
       ansible.builtin.file:
         path: "/etc/apt/sources.list.d/{{ developer_external_repos.vscode.filename }}.list"
         state: absent
-      when: not vscode_installed.stat.exists
+      when: not developer_vscode_installed.stat.exists
 
     - name: Code | Añadir el repositorio de VS Code (formato deb822 .sources)
       ansible.builtin.copy:
@@ -61,16 +61,11 @@
           Components: {{ developer_external_repos.vscode.components }}
           Architectures: {{ developer_external_repos.vscode.architectures | replace(',', ' ') }}
           Signed-By: {{ developer_external_repos.vscode.signed_by }}
-      register: vscode_repo_added
-      when: not vscode_installed.stat.exists
-
-    - name: Code | Actualizar cache de APT si el repositorio fue agregado
-      ansible.builtin.apt:
-        update_cache: true
-      when: vscode_repo_added.changed | default(false)
+      when: not developer_vscode_installed.stat.exists
 
 - name: Code | Instalar el paquete 'code'
   ansible.builtin.apt:
+    update_cache: true
     name: code
     state: present
 

--- a/roles/developer/tasks/code.yml
+++ b/roles/developer/tasks/code.yml
@@ -61,11 +61,13 @@
           Components: {{ developer_external_repos.vscode.components }}
           Architectures: {{ developer_external_repos.vscode.architectures | replace(',', ' ') }}
           Signed-By: {{ developer_external_repos.vscode.signed_by }}
+      register: developer_vscode_repo
       when: not developer_vscode_installed.stat.exists
 
 - name: Code | Instalar el paquete 'code'
   ansible.builtin.apt:
     update_cache: true
+    cache_valid_time: "{{ 0 if (developer_vscode_repo.changed | default(false)) else (apt_cache_valid_time | default(3600)) }}"
     name: code
     state: present
 

--- a/roles/developer/tasks/docker.yml
+++ b/roles/developer/tasks/docker.yml
@@ -57,10 +57,12 @@
           Components: stable
           Architectures: {{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}
           Signed-By: {{ developer_external_repos.docker.keyring_path }}
+      register: developer_docker_repo
 
     - name: Docker | Instalar Docker Engine y plugins
       ansible.builtin.apt:
         update_cache: true
+        cache_valid_time: "{{ 0 if (developer_docker_repo.changed | default(false)) else (apt_cache_valid_time | default(3600)) }}"
         name: "{{ developer_docker_packages }}"
         state: present
 

--- a/roles/developer/tasks/docker.yml
+++ b/roles/developer/tasks/docker.yml
@@ -13,31 +13,31 @@
       ansible.builtin.file:
         path: /etc/apt/keyrings
         state: directory
-        mode: '0755'
+        mode: "0755"
 
     - name: Docker | Verificar si la clave GPG ya está instalada
       ansible.builtin.stat:
         path: "{{ developer_external_repos.docker.keyring_path }}"
-      register: docker_gpg_key
+      register: developer_docker_gpg_key
 
     - name: Docker | Añadir la clave GPG oficial de Docker
       ansible.builtin.get_url:
         url: "{{ developer_external_repos.docker.gpg_url }}"
         dest: /tmp/docker.gpg
-        mode: '0644'
-      when: not docker_gpg_key.stat.exists
+        mode: "0644"
+      when: not developer_docker_gpg_key.stat.exists
 
     - name: Docker | Convertir la clave GPG al formato requerido
       ansible.builtin.command: >-
         gpg --dearmor -o {{ developer_external_repos.docker.keyring_path }} /tmp/docker.gpg
-      when: not docker_gpg_key.stat.exists
+      when: not developer_docker_gpg_key.stat.exists
       changed_when: false
 
     - name: Docker | Limpiar archivo temporal de clave GPG
       ansible.builtin.file:
         path: /tmp/docker.gpg
         state: absent
-      when: not docker_gpg_key.stat.exists
+      when: not developer_docker_gpg_key.stat.exists
 
     - name: Docker | Eliminar el repositorio legacy en formato .list (migración a deb822)
       ansible.builtin.file:
@@ -57,15 +57,10 @@
           Components: stable
           Architectures: {{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}
           Signed-By: {{ developer_external_repos.docker.keyring_path }}
-      register: docker_repo_added
-
-    - name: Docker | Actualizar cache de APT si el repositorio fue agregado
-      ansible.builtin.apt:
-        update_cache: true
-      when: docker_repo_added.changed | default(false)
 
     - name: Docker | Instalar Docker Engine y plugins
       ansible.builtin.apt:
+        update_cache: true
         name: "{{ developer_docker_packages }}"
         state: present
 

--- a/roles/developer/tasks/gh_cli.yml
+++ b/roles/developer/tasks/gh_cli.yml
@@ -33,9 +33,11 @@
           Components: {{ developer_external_repos.github_cli.components }}
           Architectures: {{ developer_external_repos.github_cli.architectures }}
           Signed-By: {{ developer_external_repos.github_cli.keyring_path }}
+      register: developer_github_repo
 
     - name: GitHub CLI | Instalar el paquete 'gh'
       ansible.builtin.apt:
         update_cache: true
+        cache_valid_time: "{{ 0 if (developer_github_repo.changed | default(false)) else (apt_cache_valid_time | default(3600)) }}"
         name: gh
         state: present

--- a/roles/developer/tasks/gh_cli.yml
+++ b/roles/developer/tasks/gh_cli.yml
@@ -6,14 +6,14 @@
     - name: GitHub CLI | Verificar si la clave GPG ya está instalada
       ansible.builtin.stat:
         path: "{{ developer_external_repos.github_cli.keyring_path }}"
-      register: github_cli_gpg_key
+      register: developer_github_cli_gpg_key
 
     - name: GitHub CLI | Descargar y colocar la clave GPG del repositorio
       ansible.builtin.get_url:
         url: "{{ developer_external_repos.github_cli.gpg_url }}"
         dest: "{{ developer_external_repos.github_cli.keyring_path }}"
-        mode: '0644'
-      when: not github_cli_gpg_key.stat.exists
+        mode: "0644"
+      when: not developer_github_cli_gpg_key.stat.exists
 
     - name: GitHub CLI | Eliminar el repositorio legacy en formato .list (migración a deb822)
       ansible.builtin.file:
@@ -33,14 +33,9 @@
           Components: {{ developer_external_repos.github_cli.components }}
           Architectures: {{ developer_external_repos.github_cli.architectures }}
           Signed-By: {{ developer_external_repos.github_cli.keyring_path }}
-      register: github_cli_repo_added
-
-    - name: GitHub CLI | Actualizar cache de APT si el repositorio fue agregado
-      ansible.builtin.apt:
-        update_cache: true
-      when: github_cli_repo_added.changed | default(false)
 
     - name: GitHub CLI | Instalar el paquete 'gh'
       ansible.builtin.apt:
+        update_cache: true
         name: gh
         state: present

--- a/roles/developer/tasks/git.yml
+++ b/roles/developer/tasks/git.yml
@@ -16,7 +16,7 @@
       ansible.builtin.file:
         path: "{{ developer_git_hooks_path }}"
         state: directory
-        mode: '0755'
+        mode: "0755"
 
     - name: Git | Copiar script de hook genérico a múltiples destinos
       ansible.builtin.copy:

--- a/roles/developer/tasks/prepare_remote_dev.yml
+++ b/roles/developer/tasks/prepare_remote_dev.yml
@@ -11,7 +11,7 @@
       ansible.builtin.file:
         path: "{{ developer_odoo_base_path }}"
         state: directory
-        mode: '0755'
+        mode: "0755"
 
     - name: Odoo Dev | Verificar si el directorio ctx existe
       ansible.builtin.stat:

--- a/roles/freelance_developer/molecule/default/prepare.yml
+++ b/roles/freelance_developer/molecule/default/prepare.yml
@@ -8,8 +8,8 @@
     - name: Prepare | Ensure systemd is available
       ansible.builtin.command: systemctl --version
       changed_when: false
-      register: freelance_systemd_check
-      failed_when: freelance_systemd_check.rc != 0
+      register: freelance_developer_systemd_check
+      failed_when: freelance_developer_systemd_check.rc != 0
 
     - name: Prepare | Create test user for SUDO_USER simulation
       ansible.builtin.user:
@@ -18,7 +18,7 @@
         create_home: true
         shell: /bin/bash
 
-    - name: Prepare | Set SUDO_USER environment for testing
+    - name: Prepare | Set SUDO_USER environment for testing  # noqa: var-naming[no-role-prefix]
       ansible.builtin.set_fact:
         ansible_env:
           SUDO_USER: testuser
@@ -27,4 +27,4 @@
       ansible.builtin.file:
         path: /tmp
         state: directory
-        mode: '1777'
+        mode: "1777"

--- a/roles/freelance_developer/molecule/default/verify.yml
+++ b/roles/freelance_developer/molecule/default/verify.yml
@@ -12,6 +12,6 @@
         - kubectl
         - gcloud
         - docker
-      register: cli_checks
+      register: freelance_developer_cli_checks
       changed_when: false
-      failed_when: cli_checks.rc != 0
+      failed_when: freelance_developer_cli_checks.rc != 0

--- a/roles/funcional/molecule/default/prepare.yml
+++ b/roles/funcional/molecule/default/prepare.yml
@@ -8,8 +8,8 @@
     - name: Prepare | Ensure systemd is running
       ansible.builtin.command: systemctl --version
       changed_when: false
-      register: systemd_check
-      failed_when: systemd_check.rc != 0
+      register: funcional_systemd_check
+      failed_when: funcional_systemd_check.rc != 0
 
     - name: Prepare | Create test user for SUDO_USER simulation
       ansible.builtin.user:
@@ -18,7 +18,7 @@
         create_home: true
         shell: /bin/bash
 
-    - name: Prepare | Set SUDO_USER environment for testing
+    - name: Prepare | Set SUDO_USER environment for testing  # noqa: var-naming[no-role-prefix]
       ansible.builtin.set_fact:
         ansible_env:
           SUDO_USER: testuser
@@ -27,4 +27,4 @@
       ansible.builtin.file:
         path: /tmp
         state: directory
-        mode: '1777'
+        mode: "1777"

--- a/roles/funcional/molecule/default/verify.yml
+++ b/roles/funcional/molecule/default/verify.yml
@@ -41,71 +41,71 @@
         state: started
         enabled: true
       check_mode: true
-      register: ssh_service
+      register: funcional_ssh_service
       failed_when: false
 
     - name: Verify | Assert SSH service is properly configured
       ansible.builtin.assert:
         that:
-          - ssh_service is not changed
+          - funcional_ssh_service is not changed
         fail_msg: "SSH service is not properly configured"
         success_msg: "SSH service is running and enabled"
 
     - name: Verify | Check UFW service status
       ansible.builtin.systemd:
         name: ufw
-      register: ufw_service
+      register: funcional_ufw_service
       failed_when: false
 
     - name: Verify | Check fail2ban service status
       ansible.builtin.systemd:
         name: fail2ban
-      register: fail2ban_service
+      register: funcional_fail2ban_service
       failed_when: false
 
     - name: Verify | Assert security services are configured
       ansible.builtin.assert:
         that:
-          - ufw_service.status.LoadState == "loaded"
-          - fail2ban_service.status.LoadState == "loaded"
+          - funcional_ufw_service.status.LoadState == "loaded"
+          - funcional_fail2ban_service.status.LoadState == "loaded"
         fail_msg: "Security services not properly configured"
         success_msg: "Security services (UFW, fail2ban) are installed and loaded"
 
     - name: Verify | Check Python3 is installed
       ansible.builtin.command: python3 --version
-      register: python_version
+      register: funcional_python_version
       changed_when: false
-      failed_when: python_version.rc != 0
+      failed_when: funcional_python_version.rc != 0
 
     - name: Verify | Check kubectl is installed
       ansible.builtin.command: kubectl version --client
-      register: kubectl_version
+      register: funcional_kubectl_version
       changed_when: false
-      failed_when: kubectl_version.rc != 0
+      failed_when: funcional_kubectl_version.rc != 0
 
     - name: Verify | Check gcloud is installed
       ansible.builtin.command: gcloud version
-      register: gcloud_version
+      register: funcional_gcloud_version
       changed_when: false
-      failed_when: gcloud_version.rc != 0
+      failed_when: funcional_gcloud_version.rc != 0
 
     - name: Verify | Check Google Chrome is installed
       ansible.builtin.command: google-chrome --version
-      register: chrome_version
+      register: funcional_chrome_version
       changed_when: false
-      failed_when: chrome_version.rc != 0
+      failed_when: funcional_chrome_version.rc != 0
 
     - name: Verify | Check adhoccli is installed (optional)
       ansible.builtin.command: which ad
-      register: adhoccli_binary
+      register: funcional_adhoccli_binary
       changed_when: false
-      failed_when: adhoccli_binary.rc not in [0, 1]
+      failed_when: funcional_adhoccli_binary.rc not in [0, 1]
 
     - name: Verify | Display adhoccli version
       ansible.builtin.command: ad
-      register: adhoccli_version
+      register: funcional_adhoccli_version
       changed_when: false
-      failed_when: adhoccli_version.rc not in [0, 1]
+      failed_when: funcional_adhoccli_version.rc not in [0, 1]
       become: true
       become_user: "testuser"
 
@@ -114,28 +114,28 @@
         name: sysadmin
         state: present
       check_mode: true
-      register: sysadmin_user
+      register: funcional_sysadmin_user
       failed_when: false
 
     - name: Verify | Check SSH configuration for security
       ansible.builtin.lineinfile:
         path: /etc/ssh/sshd_config
-        regexp: '^PasswordAuthentication'
-        line: 'PasswordAuthentication no'
+        regexp: "^PasswordAuthentication"
+        line: "PasswordAuthentication no"
         state: present
       check_mode: true
-      register: ssh_config
+      register: funcional_ssh_config
       failed_when: false
 
     - name: Verify | Check PolicyKit rules exist
       ansible.builtin.stat:
         path: /etc/polkit-1/rules.d/49-deny-sysadmin-interactive.rules
-      register: polkit_rules
+      register: funcional_polkit_rules
 
     - name: Verify | Check DNS configuration
       ansible.builtin.stat:
         path: /etc/systemd/resolved.conf
-      register: dns_config
+      register: funcional_dns_config
 
     - name: Verify | Check GPG keyrings are installed
       ansible.builtin.stat:
@@ -145,7 +145,7 @@
         - /usr/share/keyrings/google-chrome.gpg
         - /etc/apt/keyrings/kubernetes-apt-keyring.gpg
         - /usr/share/keyrings/adhoc-devops.gpg
-      register: gpg_keyrings
+      register: funcional_gpg_keyrings
 
     - name: Verify | Assert all GPG keyrings exist
       ansible.builtin.assert:
@@ -153,7 +153,7 @@
           - item.stat.exists
         fail_msg: "GPG keyring {{ item.item }} does not exist"
         success_msg: "GPG keyring {{ item.item }} is present"
-      loop: "{{ gpg_keyrings.results }}"
+      loop: "{{ funcional_gpg_keyrings.results }}"
 
     - name: Verify | Check repository source files exist
       ansible.builtin.stat:
@@ -163,7 +163,7 @@
         - /etc/apt/sources.list.d/google-chrome.sources
         - /etc/apt/sources.list.d/kubernetes-pkgs.sources
         - /etc/apt/sources.list.d/adhoc.sources
-      register: repo_files
+      register: funcional_repo_files
 
     - name: Verify | Assert all repository files exist
       ansible.builtin.assert:
@@ -171,11 +171,11 @@
           - item.stat.exists
         fail_msg: "Repository file {{ item.item }} does not exist"
         success_msg: "Repository file {{ item.item }} is present"
-      loop: "{{ repo_files.results }}"
+      loop: "{{ funcional_repo_files.results }}"
 
     - name: Verify | Check UFW firewall rules
       ansible.builtin.command: ufw status verbose
-      register: ufw_status
+      register: funcional_ufw_status
       changed_when: false
       failed_when: false
       become: true
@@ -183,12 +183,12 @@
     - name: Verify | Assert UFW is active and configured
       ansible.builtin.assert:
         that:
-          - "'Status: active' in ufw_status.stdout or 'inactive' in ufw_status.stdout"
-          - "'deny (incoming)' in ufw_status.stdout or ufw_status.rc != 0"
-          - "'allow (outgoing)' in ufw_status.stdout or ufw_status.rc != 0"
+          - "'Status: active' in funcional_ufw_status.stdout or 'inactive' in funcional_ufw_status.stdout"
+          - "'deny (incoming)' in funcional_ufw_status.stdout or funcional_ufw_status.rc != 0"
+          - "'allow (outgoing)' in funcional_ufw_status.stdout or funcional_ufw_status.rc != 0"
         fail_msg: "UFW firewall not properly configured"
         success_msg: "UFW firewall is properly configured"
-      when: ufw_status.rc == 0
+      when: funcional_ufw_status.rc == 0
 
     - name: Verify | Display test summary
       ansible.builtin.debug:
@@ -196,15 +196,15 @@
           - "✅ All required packages verified"
           - "✅ SSH service operational"
           - "✅ Security services configured"
-          - "✅ Python3 available: {{ python_version.stdout }}"
-          - "✅ kubectl available: {{ kubectl_version.stdout_lines[0] }}"
-          - "✅ gcloud available: {{ gcloud_version.stdout_lines[0] }}"
-          - "✅ Chrome available: {{ chrome_version.stdout }}"
-          - "✅ adhoccli available: {{ adhoccli_version.stdout }}"
+          - "✅ Python3 available: {{ funcional_python_version.stdout }}"
+          - "✅ kubectl available: {{ funcional_kubectl_version.stdout_lines[0] }}"
+          - "✅ gcloud available: {{ funcional_gcloud_version.stdout_lines[0] }}"
+          - "✅ Chrome available: {{ funcional_chrome_version.stdout }}"
+          - "✅ adhoccli available: {{ funcional_adhoccli_version.stdout }}"
           - "✅ sysadmin user configured"
           - "✅ SSH hardened (PasswordAuthentication disabled)"
-          - "✅ PolicyKit rules in place: {{ polkit_rules.stat.exists }}"
-          - "✅ DNS configuration present: {{ dns_config.stat.exists }}"
+          - "✅ PolicyKit rules in place: {{ funcional_polkit_rules.stat.exists }}"
+          - "✅ DNS configuration present: {{ funcional_dns_config.stat.exists }}"
           - "✅ All GPG keyrings verified (4 keyrings)"
           - "✅ All repository files verified (4 repos)"
           - "✅ UFW firewall configured correctly"

--- a/roles/funcional/tasks/adhoccli.yml
+++ b/roles/funcional/tasks/adhoccli.yml
@@ -56,10 +56,12 @@
           Suites: stable
           Components: main
           Signed-By: {{ external_repos.adhoccli.keyring_path }}
+      register: funcional_adhoc_repo
 
     - name: Adhoccli - Instalar herramientas del repositorio Adhoc
       ansible.builtin.apt:
         update_cache: true
+        cache_valid_time: "{{ 0 if (funcional_adhoc_repo.changed | default(false)) else (apt_cache_valid_time | default(3600)) }}"
         name:
           - adhoccli
           - streamsnap

--- a/roles/funcional/tasks/adhoccli.yml
+++ b/roles/funcional/tasks/adhoccli.yml
@@ -14,30 +14,30 @@
     - name: Adhoccli - Verificar si la llave GPG ya está instalada
       ansible.builtin.stat:
         path: "{{ external_repos.adhoccli.keyring_path }}"
-      register: adhoccli_gpg_key
+      register: funcional_adhoccli_gpg_key
 
     - name: Adhoccli - Descargar la llave GPG del repositorio
       ansible.builtin.get_url:
         url: "{{ external_repos.adhoccli.gpg_url }}"
         dest: /tmp/adhoc-devops.asc
         mode: "0644"
-      register: adhoccli_gpg_download
-      until: adhoccli_gpg_download is succeeded
+      register: funcional_adhoccli_gpg_download
+      until: funcional_adhoccli_gpg_download is succeeded
       retries: 3
       delay: 2
-      when: not adhoccli_gpg_key.stat.exists
+      when: not funcional_adhoccli_gpg_key.stat.exists
 
     - name: Adhoccli - Convertir y guardar la llave GPG en el keyring
       ansible.builtin.command:
         cmd: gpg --dearmor -o {{ external_repos.adhoccli.keyring_path }} /tmp/adhoc-devops.asc
-      when: not adhoccli_gpg_key.stat.exists
+      when: not funcional_adhoccli_gpg_key.stat.exists
       changed_when: true
 
     - name: Adhoccli - Remover archivo temporal de llave GPG
       ansible.builtin.file:
         path: /tmp/adhoc-devops.asc
         state: absent
-      when: not adhoccli_gpg_key.stat.exists
+      when: not funcional_adhoccli_gpg_key.stat.exists
 
     - name: Adhoccli - Eliminar el repositorio legacy en formato .list (migración a deb822)
       ansible.builtin.file:
@@ -56,15 +56,10 @@
           Suites: stable
           Components: main
           Signed-By: {{ external_repos.adhoccli.keyring_path }}
-      register: adhoccli_repo_added
-
-    - name: Adhoccli - Actualizar cache de APT si el repositorio fue agregado
-      ansible.builtin.apt:
-        update_cache: true
-      when: adhoccli_repo_added.changed
 
     - name: Adhoccli - Instalar herramientas del repositorio Adhoc
       ansible.builtin.apt:
+        update_cache: true
         name:
           - adhoccli
           - streamsnap

--- a/roles/funcional/tasks/browsers.yml
+++ b/roles/funcional/tasks/browsers.yml
@@ -62,10 +62,12 @@
           Components: main
           Architectures: amd64
           Signed-By: {{ external_repos.chrome.keyring_path }}
+      register: funcional_chrome_repo
       when: not funcional_chrome_installed.stat.exists
 
     - name: Browsers - Instalar el paquete google-chrome-stable
       ansible.builtin.apt:
         update_cache: true
+        cache_valid_time: "{{ 0 if (funcional_chrome_repo.changed | default(false)) else (apt_cache_valid_time | default(3600)) }}"
         name: google-chrome-stable
         state: present

--- a/roles/funcional/tasks/browsers.yml
+++ b/roles/funcional/tasks/browsers.yml
@@ -1,3 +1,4 @@
+---
 - name: Browsers - Instalar Google Chrome de forma limpia y segura
   tags: chrome
   become: true
@@ -10,27 +11,28 @@
     - name: Browsers - Verificar si la llave GPG ya está instalada
       ansible.builtin.stat:
         path: "{{ external_repos.chrome.keyring_path }}"
-      register: chrome_gpg_key
+      register: funcional_chrome_gpg_key
 
     - name: Browsers - Descargar y guardar la llave GPG de Google
       ansible.builtin.get_url:
         url: "{{ external_repos.chrome.gpg_url }}"
         dest: /tmp/linux_signing_key.pub
-        mode: '0644'
+        mode: "0644"
         owner: root
         group: root
-      when: not chrome_gpg_key.stat.exists
+      when: not funcional_chrome_gpg_key.stat.exists
 
     - name: Browsers - Convertir la llave GPG a keyring
       ansible.builtin.command: >
         gpg --dearmor -o {{ external_repos.chrome.keyring_path }} /tmp/linux_signing_key.pub
-      when: not chrome_gpg_key.stat.exists
+      when: not funcional_chrome_gpg_key.stat.exists
+      changed_when: true
 
     - name: Browsers - Eliminar fichero temporal de la llave
       ansible.builtin.file:
         path: /tmp/linux_signing_key.pub
         state: absent
-      when: not chrome_gpg_key.stat.exists
+      when: not funcional_chrome_gpg_key.stat.exists
 
     # El paquete google-chrome-stable autogestiona su propio archivo de repo
     # (postinst reescribe google-chrome.sources). Por eso solo configuramos el
@@ -39,13 +41,13 @@
     - name: Browsers - Verificar si Google Chrome ya está instalado
       ansible.builtin.stat:
         path: /usr/bin/google-chrome-stable
-      register: chrome_installed
+      register: funcional_chrome_installed
 
     - name: Browsers - Eliminar el repositorio legacy en formato .list (migración a deb822)
       ansible.builtin.file:
         path: /etc/apt/sources.list.d/google-chrome.list
         state: absent
-      when: not chrome_installed.stat.exists
+      when: not funcional_chrome_installed.stat.exists
 
     - name: Browsers - Añadir el repositorio de Google Chrome (formato deb822 .sources)
       ansible.builtin.copy:
@@ -60,15 +62,10 @@
           Components: main
           Architectures: amd64
           Signed-By: {{ external_repos.chrome.keyring_path }}
-      register: chrome_repo_added
-      when: not chrome_installed.stat.exists
-
-    - name: Browsers - Actualizar cache de APT si el repositorio fue agregado
-      ansible.builtin.apt:
-        update_cache: true
-      when: chrome_repo_added.changed | default(false)
+      when: not funcional_chrome_installed.stat.exists
 
     - name: Browsers - Instalar el paquete google-chrome-stable
       ansible.builtin.apt:
+        update_cache: true
         name: google-chrome-stable
         state: present

--- a/roles/funcional/tasks/fixes.yml
+++ b/roles/funcional/tasks/fixes.yml
@@ -30,23 +30,23 @@
       loop:
         - /usr/share/xsessions/gnome-xorg.desktop
         - /usr/share/xsessions/gnome.desktop
-      register: xorg_session_files
+      register: funcional_xorg_session_files
 
     - name: Arreglos | Establecer nombre de sesión Xorg encontrada
       ansible.builtin.set_fact:
-        xorg_session_name: "{{ (xorg_session_files.results | selectattr('stat.exists') | first).item | basename | replace('.desktop', '') }}"
+        funcional_xorg_session_name: "{{ (funcional_xorg_session_files.results | selectattr('stat.exists') | first).item | basename | replace('.desktop', '') }}"
 
     - name: Arreglos | Verificar si gdm3 está instalado
       ansible.builtin.stat:
         path: /etc/gdm3
-      register: gdm3_dir
+      register: funcional_gdm3_dir
 
     - name: Arreglos | Asegurar que existe el directorio /etc/gdm3
       ansible.builtin.file:
         path: /etc/gdm3
         state: directory
-        mode: '0755'
-      when: not gdm3_dir.stat.exists
+        mode: "0755"
+      when: not funcional_gdm3_dir.stat.exists
 
     - name: Arreglos | Configurar GDM3 para deshabilitar Wayland (WaylandEnable=false)
       community.general.ini_file:
@@ -55,20 +55,20 @@
         option: WaylandEnable
         value: "false"
         no_extra_spaces: true
-        mode: '0644'
+        mode: "0644"
         create: true
-      register: xorg_fix_wayland
+      register: funcional_xorg_fix_wayland
 
     - name: Arreglos | Configurar GDM3 para forzar sesión Xorg (DefaultSession)
       community.general.ini_file:
         path: /etc/gdm3/custom.conf
         section: daemon
         option: DefaultSession
-        value: "{{ xorg_session_name }}.desktop"
+        value: "{{ funcional_xorg_session_name }}.desktop"
         no_extra_spaces: true
-        mode: '0644'
+        mode: "0644"
         create: true
-      register: xorg_fix_session
+      register: funcional_xorg_fix_session
 
     - name: Arreglos | Enmascarar reglas udev que re-habilitan Wayland según GPU
       ansible.builtin.file:
@@ -76,7 +76,7 @@
         dest: /etc/udev/rules.d/61-gdm.rules
         state: link
         force: true
-      register: xorg_fix_udev
+      register: funcional_xorg_fix_udev
 
     - name: Arreglos | Forzar sesión Xorg en AccountsService (anula preferencia guardada por GDM)
       community.general.ini_file:
@@ -85,15 +85,15 @@
         option: "{{ item.key }}"
         value: "{{ item.value }}"
         no_extra_spaces: true
-        mode: '0600'
+        mode: "0600"
         create: true
       loop:
-        - { key: XSession, value: "{{ xorg_session_name }}" }
-        - { key: Session, value: "{{ xorg_session_name }}" }
+        - { key: XSession, value: "{{ funcional_xorg_session_name }}" }
+        - { key: Session, value: "{{ funcional_xorg_session_name }}" }
         - { key: SessionType, value: "x11" }
-      register: xorg_fix_accounts
+      register: funcional_xorg_fix_accounts
 
     - name: Arreglos | Informar que se requiere reinicio para aplicar cambio a Xorg
       ansible.builtin.debug:
-        msg: "GDM3 configurado para Xorg (sesión={{ xorg_session_name }}). Reiniciá el equipo para que tome efecto."
-      when: xorg_fix_wayland.changed or xorg_fix_session.changed or xorg_fix_udev.changed or xorg_fix_accounts.changed
+        msg: "GDM3 configurado para Xorg (sesión={{ funcional_xorg_session_name }}). Reiniciá el equipo para que tome efecto."
+      when: funcional_xorg_fix_wayland.changed or funcional_xorg_fix_session.changed or funcional_xorg_fix_udev.changed or funcional_xorg_fix_accounts.changed

--- a/roles/funcional/tasks/gcloud.yml
+++ b/roles/funcional/tasks/gcloud.yml
@@ -55,10 +55,12 @@
           Suites: cloud-sdk
           Components: main
           Signed-By: {{ external_repos.gcloud.keyring_path }}
+      register: funcional_gcloud_repo
 
     - name: Instalar paquetes y dependencias de gcloud
       ansible.builtin.apt:
         update_cache: true
+        cache_valid_time: "{{ 0 if (funcional_gcloud_repo.changed | default(false)) else (apt_cache_valid_time | default(3600)) }}"
         name:
           - google-cloud-cli
           - google-cloud-cli-gke-gcloud-auth-plugin

--- a/roles/funcional/tasks/gcloud.yml
+++ b/roles/funcional/tasks/gcloud.yml
@@ -3,12 +3,11 @@
   tags: gcloud
   become: true
   block:
-
     - name: Asegurar que el directorio para keyrings de APT existe
       ansible.builtin.file:
         path: /usr/share/keyrings
         state: directory
-        mode: '0755'
+        mode: "0755"
 
     - name: Asegurar que gnupg esté instalado
       ansible.builtin.apt:
@@ -18,25 +17,26 @@
     - name: Verificar si la llave GPG ya está instalada
       ansible.builtin.stat:
         path: "{{ external_repos.gcloud.keyring_path }}"
-      register: gcloud_gpg_key
+      register: funcional_gcloud_gpg_key
 
     - name: Descargar la llave GPG de Google Cloud
       ansible.builtin.get_url:
         url: "{{ external_repos.gcloud.gpg_url }}"
         dest: /tmp/google-cloud-apt-key.gpg
-        mode: '0644'
-      when: not gcloud_gpg_key.stat.exists
+        mode: "0644"
+      when: not funcional_gcloud_gpg_key.stat.exists
 
     - name: Convertir y guardar la llave GPG en /usr/share/keyrings
       ansible.builtin.command:
         cmd: gpg --dearmor -o {{ external_repos.gcloud.keyring_path }} /tmp/google-cloud-apt-key.gpg
-      when: not gcloud_gpg_key.stat.exists
+      when: not funcional_gcloud_gpg_key.stat.exists
+      changed_when: true
 
     - name: Remover archivo temporal de llave GPG
       ansible.builtin.file:
         path: /tmp/google-cloud-apt-key.gpg
         state: absent
-      when: not gcloud_gpg_key.stat.exists
+      when: not funcional_gcloud_gpg_key.stat.exists
 
     - name: Eliminar el repositorio legacy en formato .list (migración a deb822)
       ansible.builtin.file:
@@ -55,15 +55,10 @@
           Suites: cloud-sdk
           Components: main
           Signed-By: {{ external_repos.gcloud.keyring_path }}
-      register: gcloud_repo_added
-
-    - name: Actualizar cache de APT si el repositorio fue agregado
-      ansible.builtin.apt:
-        update_cache: true
-      when: gcloud_repo_added.changed
 
     - name: Instalar paquetes y dependencias de gcloud
       ansible.builtin.apt:
+        update_cache: true
         name:
           - google-cloud-cli
           - google-cloud-cli-gke-gcloud-auth-plugin

--- a/roles/funcional/tasks/kubectl.yml
+++ b/roles/funcional/tasks/kubectl.yml
@@ -16,26 +16,26 @@
     - name: Kubectl | Verificar si la clave GPG ya está instalada
       ansible.builtin.stat:
         path: "{{ external_repos.kubectl.keyring_path }}"
-      register: kubectl_gpg_key
+      register: funcional_kubectl_gpg_key
 
     - name: Kubectl | Añadir la nueva clave GPG de Kubernetes
       ansible.builtin.get_url:
         url: "{{ external_repos.kubectl.gpg_url }}"
         dest: /tmp/kubernetes-release.key
-        mode: '0644'
-      when: not kubectl_gpg_key.stat.exists
+        mode: "0644"
+      when: not funcional_kubectl_gpg_key.stat.exists
 
     - name: Kubectl | Convertir y guardar la clave GPG
       ansible.builtin.shell: >
         gpg --dearmor -o {{ external_repos.kubectl.keyring_path }} /tmp/kubernetes-release.key
-      when: not kubectl_gpg_key.stat.exists
+      when: not funcional_kubectl_gpg_key.stat.exists
       changed_when: true
 
     - name: Kubectl | Remover archivo temporal de clave GPG
       ansible.builtin.file:
         path: /tmp/kubernetes-release.key
         state: absent
-      when: not kubectl_gpg_key.stat.exists
+      when: not funcional_kubectl_gpg_key.stat.exists
 
     - name: Kubectl | Eliminar el repositorio legacy en formato .list (migración a deb822)
       ansible.builtin.file:
@@ -53,14 +53,9 @@
           URIs: {{ external_repos.kubectl.repo_url }}
           Suites: /
           Signed-By: {{ external_repos.kubectl.keyring_path }}
-      register: kubectl_repo_added
-
-    - name: Kubectl | Actualizar cache de APT si el repositorio fue agregado
-      ansible.builtin.apt:
-        update_cache: true
-      when: kubectl_repo_added.changed
 
     - name: Kubectl | Instalar kubectl
       ansible.builtin.apt:
+        update_cache: true
         name: kubectl
         state: present

--- a/roles/funcional/tasks/kubectl.yml
+++ b/roles/funcional/tasks/kubectl.yml
@@ -53,9 +53,11 @@
           URIs: {{ external_repos.kubectl.repo_url }}
           Suites: /
           Signed-By: {{ external_repos.kubectl.keyring_path }}
+      register: funcional_kubectl_repo
 
     - name: Kubectl | Instalar kubectl
       ansible.builtin.apt:
         update_cache: true
+        cache_valid_time: "{{ 0 if (funcional_kubectl_repo.changed | default(false)) else (apt_cache_valid_time | default(3600)) }}"
         name: kubectl
         state: present

--- a/roles/funcional/tasks/language.yml
+++ b/roles/funcional/tasks/language.yml
@@ -16,17 +16,17 @@
     - name: Idiomas | Establecer la configuración regional (locale) del sistema
       ansible.builtin.command: "localectl set-locale LANG=es_ES.UTF-8"
       changed_when: false
-      register: localectl_result
+      register: funcional_localectl_result
       failed_when: false
 
     - name: Idiomas | Establecer locale via /etc/default/locale (fallback)
       ansible.builtin.lineinfile:
         path: /etc/default/locale
-        regexp: '^LANG='
-        line: 'LANG=es_ES.UTF-8'
+        regexp: "^LANG="
+        line: "LANG=es_ES.UTF-8"
         create: true
-        mode: '0644'
-      when: localectl_result.rc != 0
+        mode: "0644"
+      when: funcional_localectl_result.rc != 0
 
     - name: Idiomas | Establecer las distribuciones de teclado del sistema (X11)
       ansible.builtin.command: "localectl set-x11-keymap es,us pc105 ,alt-intl"

--- a/roles/funcional/tasks/local_dns.yml
+++ b/roles/funcional/tasks/local_dns.yml
@@ -6,7 +6,6 @@
   # TODO: Investigar solución robusta para Debian
   when: ansible_facts['distribution'] == 'Ubuntu'
   block:
-    
     # 1. Instala el paquete solo en Debian (Ubuntu ya lo tiene integrado)
     # NOTA: Este bloque completo está deshabilitado en Debian, esta tarea no se ejecutará
     - name: DNS | Asegurar que systemd-resolved esté instalado (solo Debian)
@@ -34,7 +33,7 @@
         option: "{{ item.option }}"
         value: "{{ item.value }}"
         state: present
-        mode: '0644'
+        mode: "0644"
       loop:
         - { option: "DNS", value: "{{ sysadmin_public_dns_servers | join(' ') }}" }
         - { option: "FallbackDNS", value: "" }

--- a/roles/funcional/tasks/security.yml
+++ b/roles/funcional/tasks/security.yml
@@ -19,7 +19,7 @@
       community.general.ufw:
         rule: allow
         src: "{{ internal_network }}"
-        port: '22'
+        port: "22"
         proto: tcp
       notify: Restart UFW
 

--- a/roles/funcional/tasks/shortcuts.yml
+++ b/roles/funcional/tasks/shortcuts.yml
@@ -28,18 +28,18 @@
       become_user: "{{ remote_regular_user }}"
       ansible.builtin.command:
         cmd: "dconf read {{ gnome_custom_keybindings_base_path }}"
-      register: gnome_custom_keybindings_read
+      register: funcional_gnome_custom_keybindings_read
       changed_when: false
       failed_when: false
 
     - name: GNOME | Preparar lista de atajos personalizados
       ansible.builtin.set_fact:
-        gnome_custom_keybinding_paths: >-
+        funcional_gnome_custom_keybinding_paths: >-
           {{
             []
-            if (gnome_custom_keybindings_read.rc != 0
-                or (gnome_custom_keybindings_read.stdout | default('') | trim) in ['', '@as []'])
-            else (gnome_custom_keybindings_read.stdout | from_yaml)
+            if (funcional_gnome_custom_keybindings_read.rc != 0
+                or (funcional_gnome_custom_keybindings_read.stdout | default('') | trim) in ['', '@as []'])
+            else (funcional_gnome_custom_keybindings_read.stdout | from_yaml)
           }}
 
     - name: GNOME | Registrar la lista de atajos personalizados
@@ -47,7 +47,7 @@
       become_user: "{{ remote_regular_user }}"
       community.general.dconf:
         key: "{{ gnome_custom_keybindings_base_path }}"
-        value: "{{ (gnome_custom_keybinding_paths + [gnome_flameshot_shortcut_path]) | unique | list }}"
+        value: "{{ (funcional_gnome_custom_keybinding_paths + [gnome_flameshot_shortcut_path]) | unique | list }}"
         state: present
 
     - name: GNOME | Configurar claves del atajo personalizado de Flameshot

--- a/roles/funcional/tasks/user_sysadmin.yml
+++ b/roles/funcional/tasks/user_sysadmin.yml
@@ -27,7 +27,7 @@
         create: true
         owner: root
         group: root
-        mode: '0440'
+        mode: "0440"
         validate: /usr/sbin/visudo -cf %s
 
     - name: "Usuario Principal | Asegurar pertenencia al grupo sudo para: {{ remote_regular_user }}"
@@ -43,10 +43,10 @@
         line: "{{ item.key }} {{ item.value }}"
         state: present
       loop:
-        - { key: 'AllowUsers', value: 'sysadmin {{ remote_regular_user }}' }
-        - { key: 'PasswordAuthentication', value: 'no' }
-        - { key: 'ChallengeResponseAuthentication', value: 'no' }
-        - { key: 'PubkeyAuthentication', value: 'yes' }
+        - { key: "AllowUsers", value: "sysadmin {{ remote_regular_user }}" }
+        - { key: "PasswordAuthentication", value: "no" }
+        - { key: "ChallengeResponseAuthentication", value: "no" }
+        - { key: "PubkeyAuthentication", value: "yes" }
       notify: Restart sshd
 
     - name: SSH | Asegurar que el servicio SSH este habilitado y corriendo
@@ -61,7 +61,7 @@
         state: directory
         owner: root
         group: root
-        mode: '0755'
+        mode: "0755"
       changed_when: false
 
     - name: SysAdmin | Prevenir que 'sysadmin' sea usado para autenticación gráfica
@@ -70,4 +70,4 @@
         dest: /etc/polkit-1/rules.d/49-deny-sysadmin-interactive.rules
         owner: root
         group: root
-        mode: '0644'
+        mode: "0644"

--- a/roles/funcional/tasks/wine-microsip.yml
+++ b/roles/funcional/tasks/wine-microsip.yml
@@ -6,7 +6,7 @@
     # ===== 1. Habilitar arquitectura 32-bit (MicroSIP lo requiere) =====
     - name: Wine & MicroSIP | Enable 32-bit architecture support
       ansible.builtin.command: dpkg --add-architecture i386
-      register: add_arch_result
+      register: funcional_add_arch_result
       changed_when: true
 
     # ===== 2. Actualizar cache APT tras habilitar i386 =====
@@ -19,21 +19,21 @@
       ansible.builtin.file:
         path: /etc/apt/keyrings
         state: directory
-        mode: '0755'
+        mode: "0755"
 
     # ===== 4. Descargar clave GPG WineHQ =====
     - name: Wine & MicroSIP | Download WineHQ GPG key
       ansible.builtin.get_url:
         url: https://dl.winehq.org/wine-builds/winehq.key
         dest: /etc/apt/keyrings/winehq-archive.key
-        mode: '0644'
+        mode: "0644"
 
     # ===== 5. Descargar archivo .sources de WineHQ para Trixie =====
     - name: Wine & MicroSIP | Download WineHQ Trixie sources file
       ansible.builtin.get_url:
         url: https://dl.winehq.org/wine-builds/debian/dists/trixie/winehq-trixie.sources
         dest: /etc/apt/sources.list.d/winehq-trixie.sources
-        mode: '0644'
+        mode: "0644"
 
     # ===== 6. Actualizar cache APT con repo WineHQ =====
     # cache_valid_time: 0 fuerza el refresco real del índice (evita que APT
@@ -43,8 +43,8 @@
       ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 0
-      register: winehq_cache_update
-      until: winehq_cache_update is succeeded
+      register: funcional_winehq_cache_update
+      until: funcional_winehq_cache_update is succeeded
       retries: 3
       delay: 5
 
@@ -60,8 +60,8 @@
         state: present
         update_cache: true
         cache_valid_time: 0
-      register: winehq_install
-      until: winehq_install is succeeded
+      register: funcional_winehq_install
+      until: funcional_winehq_install is succeeded
       retries: 3
       delay: 10
 
@@ -91,7 +91,7 @@
       ansible.builtin.get_url:
         url: "https://www.microsip.org/download/MicroSIP-3.22.3.exe"
         dest: /tmp/MicroSIP-3.22.3.exe
-        mode: '0755'
+        mode: "0755"
         validate_certs: false
         force: true
         headers:
@@ -122,7 +122,7 @@
         state: directory
         owner: "{{ remote_regular_user }}"
         group: "{{ remote_regular_user }}"
-        mode: '0755'
+        mode: "0755"
 
     # ===== 13. Crear acceso directo de escritorio =====
     - name: Wine & MicroSIP | Create MicroSIP desktop entry
@@ -136,7 +136,7 @@
         dest: "/home/{{ remote_regular_user }}/.local/share/applications/microsip.desktop"
         owner: "{{ remote_regular_user }}"
         group: "{{ remote_regular_user }}"
-        mode: '0644'
+        mode: "0644"
 
     # ===== 14. Actualizar base de datos de aplicaciones =====
     - name: Wine & MicroSIP | Update desktop database

--- a/roles/funcional/vars.yml
+++ b/roles/funcional/vars.yml
@@ -4,7 +4,7 @@ remote_regular_user: "{{ ansible_env.SUDO_USER | default(ansible_user) }}"
 
 # INTERRUPTOR PRINCIPAL PARA EL ESTILO DE ESCRITORIOS VIRTUALES
 # Opciones válidas: 'dynamic' o 'fixed'
-gnome_workspace_style: 'dynamic'
+gnome_workspace_style: "dynamic"
 
 # Red interna permitida para SSH (ajustar según entorno)
 internal_network: "192.168.0.0/16"
@@ -205,4 +205,4 @@ external_repos:
 
 # Timeouts para descargas
 download_timeout: 30
-apt_cache_valid_time: 3600  # 1 hora
+apt_cache_valid_time: 3600 # 1 hora

--- a/roles/sysadmin/molecule/default/converge.yml
+++ b/roles/sysadmin/molecule/default/converge.yml
@@ -40,13 +40,13 @@
   roles:
     - role: sysadmin
       vars:
-        skip_gnome_tasks: true
-        developer_manage_vscode_extensions: false
-        developer_manage_vscode_defaults: false
+        skip_gnome_tasks: true  # noqa: var-naming[no-role-prefix]
+        developer_manage_vscode_extensions: false  # noqa: var-naming[no-role-prefix]
+        developer_manage_vscode_defaults: false  # noqa: var-naming[no-role-prefix]
         sysadmin_manage_vscode_extensions: false
-        developer_skip_docker: false
-        developer_skip_docker_service: true
-        developer_skip_remote_dev: true
+        developer_skip_docker: false  # noqa: var-naming[no-role-prefix]
+        developer_skip_docker_service: true  # noqa: var-naming[no-role-prefix]
+        developer_skip_remote_dev: true  # noqa: var-naming[no-role-prefix]
         sysadmin_skip_kvm: true
         sysadmin_skip_kvm_service: true
         sysadmin_skip_nordvpn: true

--- a/roles/sysadmin/molecule/default/prepare.yml
+++ b/roles/sysadmin/molecule/default/prepare.yml
@@ -18,7 +18,7 @@
         shell: /bin/bash
         create_home: true
 
-    - name: Prepare | Set SUDO_USER environment for testing
+    - name: Prepare | Set SUDO_USER environment for testing  # noqa: var-naming[no-role-prefix]
       ansible.builtin.set_fact:
         ansible_env:
           SUDO_USER: testuser
@@ -27,4 +27,4 @@
       ansible.builtin.file:
         path: /tmp
         state: directory
-        mode: '1777'
+        mode: "1777"

--- a/roles/sysadmin/molecule/default/verify.yml
+++ b/roles/sysadmin/molecule/default/verify.yml
@@ -8,12 +8,12 @@
     - ../../vars.yml
 
   vars:
-    remote_user: "{{ ansible_env.SUDO_USER | default('testuser') }}"
-    
+    sysadmin_remote_user: "{{ ansible_env.SUDO_USER | default('testuser') }}"
+
     # Paquetes específicos de sysadmin que deben estar instalados
     required_sysadmin_packages:
       - kubecolor
-    
+
     # Paquetes solo en Debian
     required_debian_packages:
       - rsync
@@ -47,19 +47,19 @@
 
     - name: Verify | Check pulumi binary
       ansible.builtin.command: pulumi version
-      register: verify_pulumi_version
+      register: sysadmin_verify_pulumi_version
       changed_when: false
-      failed_when: verify_pulumi_version.rc != 0
+      failed_when: sysadmin_verify_pulumi_version.rc != 0
 
     - name: Verify | Check helm binary
       ansible.builtin.command: helm version
-      register: verify_helm_version
+      register: sysadmin_verify_helm_version
       changed_when: false
-      failed_when: verify_helm_version.rc != 0
+      failed_when: sysadmin_verify_helm_version.rc != 0
 
     - name: Verify | Check KVM installation (skip if not installed)
       ansible.builtin.command: virsh version
-      register: verify_kvm_version
+      register: sysadmin_verify_kvm_version
       changed_when: false
       failed_when: false
       tags:
@@ -67,7 +67,7 @@
 
     - name: Verify | Check NordVPN installation (skip if not installed)
       ansible.builtin.command: nordvpn --version
-      register: verify_nordvpn_version
+      register: sysadmin_verify_nordvpn_version
       changed_when: false
       failed_when: false
       tags:
@@ -75,30 +75,30 @@
 
     - name: Verify | Check AWS CLI binary
       ansible.builtin.command: aws --version
-      register: verify_awscli_version
+      register: sysadmin_verify_awscli_version
       changed_when: false
-      failed_when: verify_awscli_version.rc != 0
+      failed_when: sysadmin_verify_awscli_version.rc != 0
 
     - name: Verify | Check aws_completer binary exists
       ansible.builtin.stat:
         path: /usr/local/bin/aws_completer
-      register: verify_awscli_completer
-      failed_when: not verify_awscli_completer.stat.exists
+      register: sysadmin_verify_awscli_completer
+      failed_when: not sysadmin_verify_awscli_completer.stat.exists
 
     - name: Verify | Check VS Code extensions for sysadmin
-      become_user: "{{ remote_user }}"
+      become_user: "{{ sysadmin_remote_user }}"
       ansible.builtin.command: code --list-extensions --no-sandbox
-      register: verify_vscode_extensions
+      register: sysadmin_verify_vscode_extensions
       changed_when: false
-      failed_when: verify_vscode_extensions.rc != 0
+      failed_when: sysadmin_verify_vscode_extensions.rc != 0
       tags:
         - molecule-notest
 
     - name: Verify | Summarize sysadmin toolchain versions
       ansible.builtin.debug:
         msg:
-          - "Pulumi version: {{ verify_pulumi_version.stdout | default('Not available') }}"
-          - "Helm version: {{ verify_helm_version.stdout | default('Not available') }}"
-          - "KVM/Libvirt version: {{ verify_kvm_version.stdout | default('Not installed') }}"
-          - "NordVPN version: {{ verify_nordvpn_version.stdout | default('Not installed') }}"
-          - "AWS CLI version: {{ verify_awscli_version.stdout | default('Not available') }}"
+          - "Pulumi version: {{ sysadmin_verify_pulumi_version.stdout | default('Not available') }}"
+          - "Helm version: {{ sysadmin_verify_helm_version.stdout | default('Not available') }}"
+          - "KVM/Libvirt version: {{ sysadmin_verify_kvm_version.stdout | default('Not installed') }}"
+          - "NordVPN version: {{ sysadmin_verify_nordvpn_version.stdout | default('Not installed') }}"
+          - "AWS CLI version: {{ sysadmin_verify_awscli_version.stdout | default('Not available') }}"

--- a/roles/sysadmin/tasks/awscli.yml
+++ b/roles/sysadmin/tasks/awscli.yml
@@ -5,7 +5,6 @@
   tags: awscli
   become: true
   block:
-
     - name: AWS CLI | Detectar instalación existente
       ansible.builtin.command: aws --version
       register: sysadmin_awscli_installed
@@ -26,7 +25,7 @@
       ansible.builtin.get_url:
         url: "https://awscli.amazonaws.com/awscli-exe-linux-{{ sysadmin_awscli_arch }}.zip"
         dest: /tmp/awscliv2.zip
-        mode: '0644'
+        mode: "0644"
         force: true
 
     - name: AWS CLI | Descomprimir instalador
@@ -53,6 +52,7 @@
           --install-dir {{ sysadmin_awscli_install_dir }}
           --bin-dir {{ sysadmin_awscli_bin_dir }}
           --update
+      changed_when: true
 
     - name: AWS CLI | Limpiar archivos temporales
       when: sysadmin_awscli_installed.rc != 0 or (sysadmin_awscli_force_update | default(false) | bool)

--- a/roles/sysadmin/tasks/helm.yml
+++ b/roles/sysadmin/tasks/helm.yml
@@ -3,13 +3,12 @@
 - name: SysAdmin - Install helm cli
   tags: helm_cli
   block:
-
     - name: Helm | Descargar script de instalación
       become: true
       ansible.builtin.get_url:
         url: https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
         dest: /tmp/get_helm.sh
-        mode: '0755'
+        mode: "0755"
       changed_when: false
 
     - name: Helm | Ejecutar script de instalación si no existe el binario
@@ -31,7 +30,7 @@
         path: "/home/{{ remote_regular_user }}/.bashrc"
         owner: "{{ remote_regular_user }}"
         group: "{{ remote_regular_user }}"
-        mode: '0644'
+        mode: "0644"
         create: true
         block: |
           if command -v helm > /dev/null; then
@@ -43,4 +42,4 @@
         path: "/home/{{ remote_regular_user }}/.bashrc"
         owner: "{{ remote_regular_user }}"
         group: "{{ remote_regular_user }}"
-        mode: '0644'
+        mode: "0644"

--- a/roles/sysadmin/tasks/kvm.yml
+++ b/roles/sysadmin/tasks/kvm.yml
@@ -13,14 +13,14 @@
         else
           echo "not_supported"
         fi
-      register: kvm_cpu_check
+      register: sysadmin_kvm_cpu_check
       changed_when: false
       failed_when: false
 
     - name: KVM | Mostrar advertencia si no hay soporte de virtualización
       ansible.builtin.debug:
         msg: "⚠️  CPU no soporta virtualización (VT-x/AMD-V). KVM no funcionará correctamente."
-      when: kvm_cpu_check.stdout == "not_supported"
+      when: sysadmin_kvm_cpu_check.stdout == "not_supported"
 
     - name: KVM | Instalar paquetes KVM y herramientas de virtualización
       ansible.builtin.apt:
@@ -43,16 +43,16 @@
 
     - name: KVM | Verificar que el módulo kvm está cargado
       ansible.builtin.shell: lsmod | grep -E '^kvm'
-      register: kvm_module_check
+      register: sysadmin_kvm_module_check
       changed_when: false
       failed_when: false
 
     - name: KVM | Información sobre módulos KVM cargados
       ansible.builtin.debug:
-        msg: "✅ Módulos KVM cargados: {{ kvm_module_check.stdout_lines }}"
-      when: kvm_module_check.rc == 0
+        msg: "✅ Módulos KVM cargados: {{ sysadmin_kvm_module_check.stdout_lines }}"
+      when: sysadmin_kvm_module_check.rc == 0
 
     - name: KVM | Advertencia si módulo KVM no está cargado
       ansible.builtin.debug:
         msg: "⚠️  Módulo KVM no detectado. Es posible que necesites habilitar VT-x/AMD-V en BIOS."
-      when: kvm_module_check.rc != 0
+      when: sysadmin_kvm_module_check.rc != 0

--- a/roles/sysadmin/tasks/nordvpn.yml
+++ b/roles/sysadmin/tasks/nordvpn.yml
@@ -52,11 +52,13 @@
           Suites: stable
           Components: main
           Signed-By: {{ sysadmin_nordvpn_gpg_path }}
+      register: sysadmin_nordvpn_repo
       when: not sysadmin_nordvpn_installed.stat.exists
 
     - name: NordVPN | Instalar el paquete de NordVPN
       ansible.builtin.apt:
         update_cache: true
+        cache_valid_time: "{{ 0 if (sysadmin_nordvpn_repo.changed | default(false)) else (apt_cache_valid_time | default(3600)) }}"
         name: "{{ sysadmin_nordvpn_package }}"
         state: present
 

--- a/roles/sysadmin/tasks/nordvpn.yml
+++ b/roles/sysadmin/tasks/nordvpn.yml
@@ -9,7 +9,7 @@
       ansible.builtin.get_url:
         url: https://repo.nordvpn.com/gpg/nordvpn_public.asc
         dest: /tmp/nordvpn_public.asc
-        mode: '0644'
+        mode: "0644"
       changed_when: false
 
     - name: NordVPN | Convertir y mover la clave GPG
@@ -32,13 +32,13 @@
     - name: NordVPN | Verificar si NordVPN ya está instalado
       ansible.builtin.stat:
         path: /usr/bin/nordvpn
-      register: nordvpn_installed
+      register: sysadmin_nordvpn_installed
 
     - name: NordVPN | Eliminar el repositorio legacy en formato .list (migración a deb822)
       ansible.builtin.file:
         path: /etc/apt/sources.list.d/nordvpn.list
         state: absent
-      when: not nordvpn_installed.stat.exists
+      when: not sysadmin_nordvpn_installed.stat.exists
 
     - name: NordVPN | Añadir el repositorio de APT de NordVPN (formato deb822 .sources)
       ansible.builtin.copy:
@@ -52,16 +52,11 @@
           Suites: stable
           Components: main
           Signed-By: {{ sysadmin_nordvpn_gpg_path }}
-      register: nordvpn_repo_added
-      when: not nordvpn_installed.stat.exists
-
-    - name: NordVPN | Actualizar cache de APT si el repositorio fue agregado
-      ansible.builtin.apt:
-        update_cache: true
-      when: nordvpn_repo_added.changed | default(false)
+      when: not sysadmin_nordvpn_installed.stat.exists
 
     - name: NordVPN | Instalar el paquete de NordVPN
       ansible.builtin.apt:
+        update_cache: true
         name: "{{ sysadmin_nordvpn_package }}"
         state: present
 

--- a/roles/sysadmin/tasks/pulumi.yml
+++ b/roles/sysadmin/tasks/pulumi.yml
@@ -52,21 +52,21 @@
       ansible.builtin.file:
         path: "{{ sysadmin_pulumi_install_root }}"
         state: directory
-        mode: '0755'
+        mode: "0755"
 
     - name: Pulumi | Download release tarball
       when: sysadmin_pulumi_version_installed_normalized != sysadmin_pulumi_version_resolved
       ansible.builtin.get_url:
         url: "https://get.pulumi.com/releases/sdk/pulumi-v{{ sysadmin_pulumi_version_resolved }}-{{ sysadmin_pulumi_arch }}.tar.gz"
         dest: "/tmp/pulumi-v{{ sysadmin_pulumi_version_resolved }}-{{ sysadmin_pulumi_arch }}.tar.gz"
-        mode: '0644'
+        mode: "0644"
 
     - name: Pulumi | Create version directory
       when: sysadmin_pulumi_version_installed_normalized != sysadmin_pulumi_version_resolved
       ansible.builtin.file:
         path: "{{ sysadmin_pulumi_install_root }}/{{ sysadmin_pulumi_version_resolved }}"
         state: directory
-        mode: '0755'
+        mode: "0755"
 
     - name: Pulumi | Extract tarball
       when: sysadmin_pulumi_version_installed_normalized != sysadmin_pulumi_version_resolved


### PR DESCRIPTION
Limpieza de warnings pre-existentes de ansible-lint, sin tocar la lógica de los roles. Sobre el código final de main (post migración deb822/copy).

- .yamllint alineado con ansible-lint para habilitar el modo --fix
- yaml (63) y fqcn (12): autofix determinístico
- no-handler (8): "update_cache when changed" fusionado como update_cache: true en la tarea de instalación (preserva orden e idempotencia; elimina registers intermedios)
- no-changed-when (10) + name (1): changed_when explícito en comandos imperativos y nombre al play de assign_laptop.yml
- var-naming (64): registers/set_facts renombrados con prefijo de rol; en molecule/ se renombró lo seguro y se anotó con # noqa los falsos positivos (override de ansible_env, vars cross-role en converge)

Restan 13 warnings de menor prioridad (ignore-errors, partial-become, risky-shell-pipe, command-instead-of-module) para revisión caso por caso. ansible-lint local.yml (CI) pasa limpio a profile production.