### PR TITLE
refactor(vars): migrar a vars/main.yml con prefijo de rol

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,12 @@
     "build": {
         "dockerfile": "Dockerfile"
     },
+    // Acceso al Docker del host (docker-outside-of-docker): monta el socket y
+    // agrega el remoteUser al grupo docker al buildear. Necesario para correr
+    // los tests de Molecule (crean contenedores en el daemon del host).
+    "features": {
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+    },
     "customizations": {
         "vscode": {
             "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,8 @@
     // agrega el remoteUser al grupo docker al buildear. Necesario para correr
     // los tests de Molecule (crean contenedores en el daemon del host).
     "features": {
-        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+        "ghcr.io/devcontainers/features/github-cli:1": {}
     },
     "customizations": {
         "vscode": {

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,7 +46,7 @@ ansible-playbook local.yml --tags "deploy" -K --verbose
 
 ### Adding a new package installation task
 1. **Identify the target role** based on the package purpose (funcional/developer/sysadmin)
-2. **Update `vars.yml`**: Add package to appropriate list variable (e.g., `developer_packages_base`, `packages_system`)
+2. **Update `vars/main.yml`**: Add package to appropriate list variable (e.g., `developer_packages_base`, `funcional_packages_system`)
 3. **Choose installation method**:
    - **Simple apt packages**: Add to existing list in `tasks/packages.yml` or `tasks/packages_dev.yml`
    - **External repository needed**: Create dedicated task file (e.g., `tasks/newtool.yml`)
@@ -82,7 +82,7 @@ ansible-playbook local.yml --tags "deploy" -K --verbose
 ## Project Conventions
 
 ### File organization
-- Each role has: `tasks/main.yml` (orchestrator), `vars.yml` (variables), individual `tasks/*.yml` (feature-specific)
+- Each role has: `tasks/main.yml` (orchestrator), `vars/main.yml` (variables), individual `tasks/*.yml` (feature-specific)
 - `tasks/main.yml` imports all feature tasks in sequence (e.g., `packages.yml`, `docker.yml`, `code.yml`)
 - Configuration files stored in `files/` directory, Jinja2 templates in `templates/`
 - All roles tagged with their profile name (e.g., `tags: developer`, `tags: funcional`)
@@ -90,7 +90,7 @@ ansible-playbook local.yml --tags "deploy" -K --verbose
 ### Variable patterns
 - **User detection**: `remote_regular_user: "{{ ansible_env.SUDO_USER | default(ansible_user) }}"` - critical for running tasks as the actual user when using `sudo`
 - **Distribution version logic**: Use `ansible_facts['distribution_version']` for Debian version-specific behavior
-- **Package exclusions**: `packages_exclude_debian_13` pattern for distro-specific package availability
+- **Package exclusions**: `funcional_packages_exclude_debian_13` pattern for distro-specific package availability
 - Variables prefixed with role name: `developer_*`, `funcional_*`, `sysadmin_*`
 
 ### Task structure patterns
@@ -182,5 +182,5 @@ Manual testing in VirtualBox VMs with clean Debian 13 installations.
 
 - `local.yml`: Main playbook orchestration logic
 - `roles/{profile}/tasks/main.yml`: Entry points showing feature organization
-- `roles/{profile}/vars.yml`: Profile-specific variable definitions
+- `roles/{profile}/vars/main.yml`: Profile-specific variable definitions
 - `launch_project.sh`: Bootstrap script pattern for understanding initial setup flow

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -11,7 +11,50 @@ on:
       - main
       - develop
   workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  changes:
+    name: Detect changed roles
+    runs-on: ubuntu-latest
+    outputs:
+      funcional: ${{ steps.filter.outputs.funcional }}
+      developer: ${{ steps.filter.outputs.developer }}
+      sysadmin: ${{ steps.filter.outputs.sysadmin }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Filter paths por rol (respeta el grafo de dependencias)
+        # funcional es base; developer depende de funcional; sysadmin de developer.
+        # Por eso cada filtro incluye los paths de los roles de los que depende:
+        # tocar funcional re-testea los 3, developer re-testea developer+sysadmin.
+        # 'shared' = archivos que afectan a todos (play, deps, el propio workflow).
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            shared: &shared
+              - 'local.yml'
+              - 'collections/requirements.yml'
+              - 'requirements-dev.txt'
+              - '.github/workflows/molecule.yml'
+            funcional:
+              - *shared
+              - 'roles/funcional/**'
+            developer:
+              - *shared
+              - 'roles/funcional/**'
+              - 'roles/developer/**'
+            sysadmin:
+              - *shared
+              - 'roles/funcional/**'
+              - 'roles/developer/**'
+              - 'roles/sysadmin/**'
+
   lint:
     name: Lint Ansible code
     runs-on: ubuntu-latest
@@ -81,7 +124,8 @@ jobs:
   test-funcional:
     name: Test funcional role
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, changes]
+    if: needs.changes.outputs.funcional == 'true'
 
     steps:
       - name: Checkout code
@@ -135,7 +179,8 @@ jobs:
   test-developer:
     name: Test developer role
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, changes]
+    if: needs.changes.outputs.developer == 'true'
 
     steps:
       - name: Checkout code
@@ -189,7 +234,8 @@ jobs:
   test-sysadmin:
     name: Test sysadmin role
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, changes]
+    if: needs.changes.outputs.sysadmin == 'true'
 
     steps:
       - name: Checkout code
@@ -256,36 +302,29 @@ jobs:
           echo "| Role | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
 
-          # Funcional
-          if [ "${{ needs.test-funcional.result }}" == "success" ]; then
-            echo "| funcional | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "| funcional | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
-          fi
-
-          # Developer
-          if [ "${{ needs.test-developer.result }}" == "success" ]; then
-            echo "| developer | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "| developer | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
-          fi
-
-          # Sysadmin
-          if [ "${{ needs.test-sysadmin.result }}" == "success" ]; then
-            echo "| sysadmin | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "| sysadmin | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
-          fi
+          # Una fila por rol. 'skipped' = no hubo cambios que afecten ese rol.
+          row() {
+            case "$2" in
+              success) echo "| $1 | ✅ Passed |" >> $GITHUB_STEP_SUMMARY ;;
+              skipped) echo "| $1 | ⏭️ Skipped (sin cambios) |" >> $GITHUB_STEP_SUMMARY ;;
+              *)       echo "| $1 | ❌ Failed |" >> $GITHUB_STEP_SUMMARY ;;
+            esac
+          }
+          row funcional "${{ needs.test-funcional.result }}"
+          row developer "${{ needs.test-developer.result }}"
+          row sysadmin "${{ needs.test-sysadmin.result }}"
 
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## Platforms Tested" >> $GITHUB_STEP_SUMMARY
           echo "- 🐧 Debian 13 (Trixie)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Overall status
-          if [ "${{ needs.test-funcional.result }}" == "success" ] && \
-             [ "${{ needs.test-developer.result }}" == "success" ] && \
-             [ "${{ needs.test-sysadmin.result }}" == "success" ]; then
+          # Overall status: 'skipped' (sin cambios para ese rol) cuenta como OK;
+          # solo 'failure'/'cancelled' marcan el resumen como fallido.
+          ok() { [ "$1" == "success" ] || [ "$1" == "skipped" ]; }
+          if ok "${{ needs.test-funcional.result }}" && \
+             ok "${{ needs.test-developer.result }}" && \
+             ok "${{ needs.test-sysadmin.result }}"; then
             echo "## ✅ Overall Status: SUCCESS" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "All tests passed successfully! 🎉" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ Registro de cambios relevantes del proyecto. Formato basado en [Keep a Changelog
 - `remote_regular_user`/`remote_regular_user_uid` se mantienen sin prefijo (alias play-wide compartido a propósito) con `# noqa` documentado
 - `deploy` y `freelance_developer` actualizados para cargar las vars del rol de origen desde `vars/main.yml`
 - Nueva sección `specifications.md` §3.5 documentando la convención de nombres de variables
-- DevContainer: agregado el feature `docker-outside-of-docker` para poder correr los tests de Molecule contra el daemon del host
-- `ansible-lint local.yml` pasa limpio a profile `production`; syntax-check OK en los 4 perfiles. **Pendiente: validación con `molecule test` tras rebuild del devcontainer**
+- DevContainer: agregados los features `docker-outside-of-docker` (correr Molecule contra el daemon del host) y `github-cli` (gestionar PRs sin instalar `gh` manualmente)
+- `ansible-lint local.yml` pasa limpio a profile `production`; syntax-check OK en los 4 perfiles. Validado con `molecule test`: los 4 roles (funcional, developer, sysadmin, freelance_developer) pasan converge + idempotence (changed=0) + verify (exit 0)
 
 ### Limpieza de estructura: documentación, scripts y consistencia
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Registro de cambios relevantes del proyecto. Formato basado en [Keep a Changelog
 
 ## [2026-06-26]
 
+### Variables: migración a `vars/main.yml` con prefijo de rol
+
+- Movidas las variables de cada rol de `roles/<rol>/vars.yml` (cargado vía `include_vars` manual) a `roles/<rol>/vars/main.yml` (autocarga estándar de Ansible). Eliminados los `include_vars` redundantes de funcional/developer/sysadmin
+- Prefijadas con el nombre del rol todas las variables internas que no lo tenían (~28 en `funcional`: `funcional_packages_*`, `funcional_dconf_settings`, `funcional_branding_*`, `funcional_external_repos`, `funcional_gnome_*`, etc.; `sysadmin_vscode_extension_list`). Cumple `var-naming[no-role-prefix]` y evita colisiones en el namespace global del play
+- `remote_regular_user`/`remote_regular_user_uid` se mantienen sin prefijo (alias play-wide compartido a propósito) con `# noqa` documentado
+- `deploy` y `freelance_developer` actualizados para cargar las vars del rol de origen desde `vars/main.yml`
+- Nueva sección `specifications.md` §3.5 documentando la convención de nombres de variables
+- DevContainer: agregado el feature `docker-outside-of-docker` para poder correr los tests de Molecule contra el daemon del host
+- `ansible-lint local.yml` pasa limpio a profile `production`; syntax-check OK en los 4 perfiles. **Pendiente: validación con `molecule test` tras rebuild del devcontainer**
+
 ### Limpieza de estructura: documentación, scripts y consistencia
 
 - **Documentación consolidada**: testing unificado en un único `docs/TESTING.md`

--- a/README.md
+++ b/README.md
@@ -244,8 +244,8 @@ sudo reboot
 ### Error: Paquete no disponible en Debian 13
 
 ```yaml
-# Solución: Agregar a packages_exclude_debian_13 en vars.yml
-packages_exclude_debian_13:
+# Solución: Agregar a funcional_packages_exclude_debian_13 en vars/main.yml
+funcional_packages_exclude_debian_13:
   - nombre-paquete-problemático
 ```
 

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -1,14 +1,11 @@
 ---
-- name: Include vars
-  ansible.builtin.include_vars: "{{ role_path }}/vars.yml"
-  tags: always
-
-# Las tareas reutilizadas (kubectl/gcloud) dependen de vars definidas en
-# funcional/vars.yml (external_repos, funcional_kubectl_prerequisites). Las
-# cargamos explícitamente para que el rol 'deploy' sea autocontenido y no dependa
-# de que el rol 'funcional' haya corrido antes en el mismo play.
-- name: Include vars from funcional (external_repos, etc.)
-  ansible.builtin.include_vars: "{{ role_path | dirname }}/funcional/vars.yml"
+# Los vars propios del rol se cargan automáticamente desde vars/main.yml.
+# Además, las tareas reutilizadas (kubectl/gcloud) dependen de vars de funcional
+# (funcional_external_repos, funcional_kubectl_prerequisites): como se importan vía
+# import_tasks con ruta relativa (no import_role), funcional/vars/main.yml NO se
+# autocarga, así que lo incluimos explícitamente.
+- name: Include vars from funcional (funcional_external_repos, etc.)
+  ansible.builtin.include_vars: "{{ role_path | dirname }}/funcional/vars/main.yml"
   tags: always
 
 # NOTA: se reutilizan los archivos de tareas de funcional/sysadmin vía

--- a/roles/deploy/vars/main.yml
+++ b/roles/deploy/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 # Usuario genérico para ejecutar algunas tareas
-remote_regular_user: "{{ ansible_env.SUDO_USER | default(ansible_user) }}"
+remote_regular_user: "{{ ansible_env.SUDO_USER | default(ansible_user) }}"  # noqa: var-naming[no-role-prefix]
 
 # --- Configuración para Pulumi ---
 # Por defecto instala la última release estable. Para pinnear:

--- a/roles/developer/molecule/default/verify.yml
+++ b/roles/developer/molecule/default/verify.yml
@@ -5,7 +5,7 @@
   become: true
 
   vars_files:
-    - ../../vars.yml
+    - ../../vars/main.yml
 
   vars:
     developer_remote_user: "{{ ansible_env.SUDO_USER | default('testuser') }}"

--- a/roles/developer/tasks/code.yml
+++ b/roles/developer/tasks/code.yml
@@ -67,7 +67,7 @@
 - name: Code | Instalar el paquete 'code'
   ansible.builtin.apt:
     update_cache: true
-    cache_valid_time: "{{ 0 if (developer_vscode_repo.changed | default(false)) else (apt_cache_valid_time | default(3600)) }}"
+    cache_valid_time: "{{ 0 if (developer_vscode_repo.changed | default(false)) else (funcional_apt_cache_valid_time | default(3600)) }}"
     name: code
     state: present
 

--- a/roles/developer/tasks/docker.yml
+++ b/roles/developer/tasks/docker.yml
@@ -62,7 +62,7 @@
     - name: Docker | Instalar Docker Engine y plugins
       ansible.builtin.apt:
         update_cache: true
-        cache_valid_time: "{{ 0 if (developer_docker_repo.changed | default(false)) else (apt_cache_valid_time | default(3600)) }}"
+        cache_valid_time: "{{ 0 if (developer_docker_repo.changed | default(false)) else (funcional_apt_cache_valid_time | default(3600)) }}"
         name: "{{ developer_docker_packages }}"
         state: present
 

--- a/roles/developer/tasks/gh_cli.yml
+++ b/roles/developer/tasks/gh_cli.yml
@@ -38,6 +38,6 @@
     - name: GitHub CLI | Instalar el paquete 'gh'
       ansible.builtin.apt:
         update_cache: true
-        cache_valid_time: "{{ 0 if (developer_github_repo.changed | default(false)) else (apt_cache_valid_time | default(3600)) }}"
+        cache_valid_time: "{{ 0 if (developer_github_repo.changed | default(false)) else (funcional_apt_cache_valid_time | default(3600)) }}"
         name: gh
         state: present

--- a/roles/developer/tasks/main.yml
+++ b/roles/developer/tasks/main.yml
@@ -1,9 +1,5 @@
 ---
-- name: Include vars
-  ansible.builtin.include_vars: "{{ role_path }}/vars.yml"
-  tags: always
-  no_log: true
-
+# Las variables del rol se cargan automáticamente desde vars/main.yml
 - name: Include
   block:
     - name: Developer - Packages

--- a/roles/developer/tasks/packages_dev.yml
+++ b/roles/developer/tasks/packages_dev.yml
@@ -5,4 +5,4 @@
   ansible.builtin.apt:
     name: "{{ developer_packages_base }}"
     state: present
-    cache_valid_time: "{{ apt_cache_valid_time | default(3600) }}"
+    cache_valid_time: "{{ funcional_apt_cache_valid_time | default(3600) }}"

--- a/roles/developer/tasks/python.yml
+++ b/roles/developer/tasks/python.yml
@@ -5,7 +5,7 @@
   ansible.builtin.apt:
     name: "{{ developer_python_packages }}"
     state: present
-    cache_valid_time: "{{ apt_cache_valid_time | default(3600) }}"
+    cache_valid_time: "{{ funcional_apt_cache_valid_time | default(3600) }}"
 
 - name: Python | Gestionar entorno virtual y herramientas de linting
   tags: python

--- a/roles/developer/vars/main.yml
+++ b/roles/developer/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 # Usuario genérico para ejecutar algunas tareas
-remote_regular_user: "{{ ansible_env.SUDO_USER | default(ansible_user) }}"
-remote_regular_user_uid: "{{ ansible_env.SUDO_UID | default(ansible_user_uid) }}"
+remote_regular_user: "{{ ansible_env.SUDO_USER | default(ansible_user) }}"  # noqa: var-naming[no-role-prefix]
+remote_regular_user_uid: "{{ ansible_env.SUDO_UID | default(ansible_user_uid) }}"  # noqa: var-naming[no-role-prefix]
 
 # Lista de paquetes base para el perfil de DEV
 developer_packages_base:

--- a/roles/freelance_developer/tasks/main.yml
+++ b/roles/freelance_developer/tasks/main.yml
@@ -1,11 +1,13 @@
 ---
+# freelance_developer no hereda funcional/developer vía meta (corre un subset con
+# tasks_from y skip de dependencias), así que carga sus vars explícitamente.
 - name: Freelance Developer | Include vars from funcional
-  ansible.builtin.include_vars: "{{ role_path | dirname }}/funcional/vars.yml"
+  ansible.builtin.include_vars: "{{ role_path | dirname }}/funcional/vars/main.yml"
   tags: always
   no_log: true
 
 - name: Freelance Developer | Include vars from developer
-  ansible.builtin.include_vars: "{{ role_path | dirname }}/developer/vars.yml"
+  ansible.builtin.include_vars: "{{ role_path | dirname }}/developer/vars/main.yml"
   tags: always
   no_log: true
 

--- a/roles/funcional/README.md
+++ b/roles/funcional/README.md
@@ -21,9 +21,9 @@ Rol base para estaciones de trabajo de Adhoc. Instala y configura las aplicacion
 ## Variables Importantes
 
 ### Paquetes
-- `packages_system`: Paquetes de sistema esenciales
+- `funcional_packages_system`: Paquetes de sistema esenciales
 - `packages_apps`: Aplicaciones de usuario
-- `packages_exclude_debian_13`: Paquetes que no están en Debian 13
+- `funcional_packages_exclude_debian_13`: Paquetes que no están en Debian 13
 
 ### Seguridad
 - Usuario `sysadmin` con UID 499
@@ -106,10 +106,10 @@ El flujo de trabajo, troubleshooting y cómo agregar tests están documentados e
 ## Mantenimiento
 
 ### Actualizar versiones de paquetes
-Editar `vars.yml` y actualizar las listas de paquetes.
+Editar `vars/main.yml` y actualizar las listas de paquetes.
 
 ### Agregar nuevos paquetes
-1. Agregar a la lista apropiada en `vars.yml`
+1. Agregar a la lista apropiada en `vars/main.yml`
 2. Actualizar test de verificación en `molecule/default/verify.yml`
 3. Ejecutar `molecule test` para validar
 

--- a/roles/funcional/README.md
+++ b/roles/funcional/README.md
@@ -22,7 +22,7 @@ Rol base para estaciones de trabajo de Adhoc. Instala y configura las aplicacion
 
 ### Paquetes
 - `funcional_packages_system`: Paquetes de sistema esenciales
-- `packages_apps`: Aplicaciones de usuario
+- `funcional_packages_apps`: Aplicaciones de usuario
 - `funcional_packages_exclude_debian_13`: Paquetes que no están en Debian 13
 
 ### Seguridad

--- a/roles/funcional/tasks/adhoccli.yml
+++ b/roles/funcional/tasks/adhoccli.yml
@@ -13,12 +13,12 @@
 
     - name: Adhoccli - Verificar si la llave GPG ya está instalada
       ansible.builtin.stat:
-        path: "{{ external_repos.adhoccli.keyring_path }}"
+        path: "{{ funcional_external_repos.adhoccli.keyring_path }}"
       register: funcional_adhoccli_gpg_key
 
     - name: Adhoccli - Descargar la llave GPG del repositorio
       ansible.builtin.get_url:
-        url: "{{ external_repos.adhoccli.gpg_url }}"
+        url: "{{ funcional_external_repos.adhoccli.gpg_url }}"
         dest: /tmp/adhoc-devops.asc
         mode: "0644"
       register: funcional_adhoccli_gpg_download
@@ -29,7 +29,7 @@
 
     - name: Adhoccli - Convertir y guardar la llave GPG en el keyring
       ansible.builtin.command:
-        cmd: gpg --dearmor -o {{ external_repos.adhoccli.keyring_path }} /tmp/adhoc-devops.asc
+        cmd: gpg --dearmor -o {{ funcional_external_repos.adhoccli.keyring_path }} /tmp/adhoc-devops.asc
       when: not funcional_adhoccli_gpg_key.stat.exists
       changed_when: true
 
@@ -52,16 +52,16 @@
         mode: "0644"
         content: |
           Types: deb
-          URIs: {{ external_repos.adhoccli.repo_url }}
+          URIs: {{ funcional_external_repos.adhoccli.repo_url }}
           Suites: stable
           Components: main
-          Signed-By: {{ external_repos.adhoccli.keyring_path }}
+          Signed-By: {{ funcional_external_repos.adhoccli.keyring_path }}
       register: funcional_adhoc_repo
 
     - name: Adhoccli - Instalar herramientas del repositorio Adhoc
       ansible.builtin.apt:
         update_cache: true
-        cache_valid_time: "{{ 0 if (funcional_adhoc_repo.changed | default(false)) else (apt_cache_valid_time | default(3600)) }}"
+        cache_valid_time: "{{ 0 if (funcional_adhoc_repo.changed | default(false)) else (funcional_apt_cache_valid_time | default(3600)) }}"
         name:
           - adhoccli
           - streamsnap

--- a/roles/funcional/tasks/branding.yml
+++ b/roles/funcional/tasks/branding.yml
@@ -9,7 +9,7 @@
     owner: "{{ remote_regular_user }}"
     group: "{{ remote_regular_user }}"
     mode: "0644"
-  loop: "{{ branding_files_to_copy }}"
+  loop: "{{ funcional_branding_files_to_copy }}"
 
 - name: Branding | Aplicar configuraciones de fondo de pantalla y protector
   tags: branding
@@ -19,5 +19,5 @@
     key: "{{ item.key }}"
     value: "{{ item.value }}"
     state: present
-  loop: "{{ branding_dconf_settings }}"
+  loop: "{{ funcional_branding_dconf_settings }}"
   when: not (skip_gnome_tasks | default(false))

--- a/roles/funcional/tasks/browsers.yml
+++ b/roles/funcional/tasks/browsers.yml
@@ -10,12 +10,12 @@
 
     - name: Browsers - Verificar si la llave GPG ya está instalada
       ansible.builtin.stat:
-        path: "{{ external_repos.chrome.keyring_path }}"
+        path: "{{ funcional_external_repos.chrome.keyring_path }}"
       register: funcional_chrome_gpg_key
 
     - name: Browsers - Descargar y guardar la llave GPG de Google
       ansible.builtin.get_url:
-        url: "{{ external_repos.chrome.gpg_url }}"
+        url: "{{ funcional_external_repos.chrome.gpg_url }}"
         dest: /tmp/linux_signing_key.pub
         mode: "0644"
         owner: root
@@ -24,7 +24,7 @@
 
     - name: Browsers - Convertir la llave GPG a keyring
       ansible.builtin.command: >
-        gpg --dearmor -o {{ external_repos.chrome.keyring_path }} /tmp/linux_signing_key.pub
+        gpg --dearmor -o {{ funcional_external_repos.chrome.keyring_path }} /tmp/linux_signing_key.pub
       when: not funcional_chrome_gpg_key.stat.exists
       changed_when: true
 
@@ -57,17 +57,17 @@
         mode: "0644"
         content: |
           Types: deb
-          URIs: {{ external_repos.chrome.repo_url }}
+          URIs: {{ funcional_external_repos.chrome.repo_url }}
           Suites: stable
           Components: main
           Architectures: amd64
-          Signed-By: {{ external_repos.chrome.keyring_path }}
+          Signed-By: {{ funcional_external_repos.chrome.keyring_path }}
       register: funcional_chrome_repo
       when: not funcional_chrome_installed.stat.exists
 
     - name: Browsers - Instalar el paquete google-chrome-stable
       ansible.builtin.apt:
         update_cache: true
-        cache_valid_time: "{{ 0 if (funcional_chrome_repo.changed | default(false)) else (apt_cache_valid_time | default(3600)) }}"
+        cache_valid_time: "{{ 0 if (funcional_chrome_repo.changed | default(false)) else (funcional_apt_cache_valid_time | default(3600)) }}"
         name: google-chrome-stable
         state: present

--- a/roles/funcional/tasks/ext.yml
+++ b/roles/funcional/tasks/ext.yml
@@ -7,5 +7,5 @@
     key: "{{ item.key }}"
     value: "{{ item.value }}"
     state: present
-  loop: "{{ dconf_settings }}" # Usamos la sintaxis moderna 'loop'
+  loop: "{{ funcional_dconf_settings }}" # Usamos la sintaxis moderna 'loop'
   when: not (skip_gnome_tasks | default(false))

--- a/roles/funcional/tasks/fixes.yml
+++ b/roles/funcional/tasks/fixes.yml
@@ -5,7 +5,7 @@
   become_user: "{{ remote_regular_user }}"
   community.general.dconf:
     key: "/org/gnome/shell/favorite-apps"
-    value: "{{ gnome_functional_favorite_apps }}"
+    value: "{{ funcional_gnome_functional_favorite_apps }}"
     state: present
   when: not (skip_gnome_tasks | default(false))
 

--- a/roles/funcional/tasks/gcloud.yml
+++ b/roles/funcional/tasks/gcloud.yml
@@ -16,19 +16,19 @@
 
     - name: Verificar si la llave GPG ya está instalada
       ansible.builtin.stat:
-        path: "{{ external_repos.gcloud.keyring_path }}"
+        path: "{{ funcional_external_repos.gcloud.keyring_path }}"
       register: funcional_gcloud_gpg_key
 
     - name: Descargar la llave GPG de Google Cloud
       ansible.builtin.get_url:
-        url: "{{ external_repos.gcloud.gpg_url }}"
+        url: "{{ funcional_external_repos.gcloud.gpg_url }}"
         dest: /tmp/google-cloud-apt-key.gpg
         mode: "0644"
       when: not funcional_gcloud_gpg_key.stat.exists
 
     - name: Convertir y guardar la llave GPG en /usr/share/keyrings
       ansible.builtin.command:
-        cmd: gpg --dearmor -o {{ external_repos.gcloud.keyring_path }} /tmp/google-cloud-apt-key.gpg
+        cmd: gpg --dearmor -o {{ funcional_external_repos.gcloud.keyring_path }} /tmp/google-cloud-apt-key.gpg
       when: not funcional_gcloud_gpg_key.stat.exists
       changed_when: true
 
@@ -51,16 +51,16 @@
         mode: "0644"
         content: |
           Types: deb
-          URIs: {{ external_repos.gcloud.repo_url }}
+          URIs: {{ funcional_external_repos.gcloud.repo_url }}
           Suites: cloud-sdk
           Components: main
-          Signed-By: {{ external_repos.gcloud.keyring_path }}
+          Signed-By: {{ funcional_external_repos.gcloud.keyring_path }}
       register: funcional_gcloud_repo
 
     - name: Instalar paquetes y dependencias de gcloud
       ansible.builtin.apt:
         update_cache: true
-        cache_valid_time: "{{ 0 if (funcional_gcloud_repo.changed | default(false)) else (apt_cache_valid_time | default(3600)) }}"
+        cache_valid_time: "{{ 0 if (funcional_gcloud_repo.changed | default(false)) else (funcional_apt_cache_valid_time | default(3600)) }}"
         name:
           - google-cloud-cli
           - google-cloud-cli-gke-gcloud-auth-plugin

--- a/roles/funcional/tasks/kubectl.yml
+++ b/roles/funcional/tasks/kubectl.yml
@@ -15,19 +15,19 @@
 
     - name: Kubectl | Verificar si la clave GPG ya está instalada
       ansible.builtin.stat:
-        path: "{{ external_repos.kubectl.keyring_path }}"
+        path: "{{ funcional_external_repos.kubectl.keyring_path }}"
       register: funcional_kubectl_gpg_key
 
     - name: Kubectl | Añadir la nueva clave GPG de Kubernetes
       ansible.builtin.get_url:
-        url: "{{ external_repos.kubectl.gpg_url }}"
+        url: "{{ funcional_external_repos.kubectl.gpg_url }}"
         dest: /tmp/kubernetes-release.key
         mode: "0644"
       when: not funcional_kubectl_gpg_key.stat.exists
 
     - name: Kubectl | Convertir y guardar la clave GPG
       ansible.builtin.shell: >
-        gpg --dearmor -o {{ external_repos.kubectl.keyring_path }} /tmp/kubernetes-release.key
+        gpg --dearmor -o {{ funcional_external_repos.kubectl.keyring_path }} /tmp/kubernetes-release.key
       when: not funcional_kubectl_gpg_key.stat.exists
       changed_when: true
 
@@ -50,14 +50,14 @@
         mode: "0644"
         content: |
           Types: deb
-          URIs: {{ external_repos.kubectl.repo_url }}
+          URIs: {{ funcional_external_repos.kubectl.repo_url }}
           Suites: /
-          Signed-By: {{ external_repos.kubectl.keyring_path }}
+          Signed-By: {{ funcional_external_repos.kubectl.keyring_path }}
       register: funcional_kubectl_repo
 
     - name: Kubectl | Instalar kubectl
       ansible.builtin.apt:
         update_cache: true
-        cache_valid_time: "{{ 0 if (funcional_kubectl_repo.changed | default(false)) else (apt_cache_valid_time | default(3600)) }}"
+        cache_valid_time: "{{ 0 if (funcional_kubectl_repo.changed | default(false)) else (funcional_apt_cache_valid_time | default(3600)) }}"
         name: kubectl
         state: present

--- a/roles/funcional/tasks/language.yml
+++ b/roles/funcional/tasks/language.yml
@@ -5,7 +5,7 @@
   block:
     - name: Idiomas | Instalar paquetes de idioma
       ansible.builtin.apt:
-        name: "{{ language_packs_debian }}"
+        name: "{{ funcional_language_packs_debian }}"
         state: present
 
     - name: Idiomas | Asegurar que el locale 'es_ES.UTF-8' esté generado
@@ -38,6 +38,6 @@
       become_user: "{{ remote_regular_user }}"
       community.general.dconf:
         key: "/org/gnome/desktop/input-sources/sources"
-        value: "{{ keyboard_layouts | trim }}"
+        value: "{{ funcional_keyboard_layouts | trim }}"
         state: present
       when: not (skip_gnome_tasks | default(false))

--- a/roles/funcional/tasks/local_dns.yml
+++ b/roles/funcional/tasks/local_dns.yml
@@ -35,7 +35,7 @@
         state: present
         mode: "0644"
       loop:
-        - { option: "DNS", value: "{{ sysadmin_public_dns_servers | join(' ') }}" }
+        - { option: "DNS", value: "{{ funcional_public_dns_servers | join(' ') }}" }
         - { option: "FallbackDNS", value: "" }
         - { option: "DNSOverTLS", value: "yes" }
       notify: Restart systemd-resolved # Asumo que tienes este handler definido

--- a/roles/funcional/tasks/main.yml
+++ b/roles/funcional/tasks/main.yml
@@ -1,9 +1,5 @@
 ---
-- name: Include vars
-  ansible.builtin.include_vars: "{{ role_path }}/vars.yml"
-  tags: always
-  no_log: true
-
+# Las variables del rol se cargan automáticamente desde vars/main.yml
 - name: Actualizar cache de APT una sola vez al inicio
   ansible.builtin.apt:
     update_cache: true

--- a/roles/funcional/tasks/packages.yml
+++ b/roles/funcional/tasks/packages.yml
@@ -3,14 +3,14 @@
   tags: packages_funcional
   vars:
     all_packages_to_install: >-
-      {{ packages_system +
-         packages_compression +
-         packages_apps +
-         packages_hardware_analysis +
-         packages_gui_utils }}
+      {{ funcional_packages_system +
+         funcional_packages_compression +
+         funcional_packages_apps +
+         funcional_packages_hardware_analysis +
+         funcional_packages_gui_utils }}
 
     excluded_packages: >-
-      {{ packages_exclude_debian_13 if ansible_facts['distribution'] == 'Debian' and ansible_facts['distribution_major_version'] == '13' else [] }}
+      {{ funcional_packages_exclude_debian_13 if ansible_facts['distribution'] == 'Debian' and ansible_facts['distribution_major_version'] == '13' else [] }}
 
   ansible.builtin.apt:
     name: "{{ all_packages_to_install | difference(excluded_packages) }}"
@@ -20,6 +20,6 @@
   tags: packages_funcional
   become: true
   ansible.builtin.apt:
-    name: "{{ packages_to_remove }}"
+    name: "{{ funcional_packages_to_remove }}"
     state: absent
     purge: true

--- a/roles/funcional/tasks/security.yml
+++ b/roles/funcional/tasks/security.yml
@@ -18,7 +18,7 @@
     - name: Firewall | Permitir SSH desde la red interna
       community.general.ufw:
         rule: allow
-        src: "{{ internal_network }}"
+        src: "{{ funcional_internal_network }}"
         port: "22"
         proto: tcp
       notify: Restart UFW

--- a/roles/funcional/tasks/shortcuts.yml
+++ b/roles/funcional/tasks/shortcuts.yml
@@ -7,7 +7,7 @@
     key: "{{ item.key }}"
     value: "{{ item.value }}"
     state: present
-  loop: "{{ gnome_keybindings | from_yaml }}"
+  loop: "{{ funcional_gnome_keybindings | from_yaml }}"
   when: not (skip_gnome_tasks | default(false))
 
 - name: GNOME | Configurar atajo personalizado de Flameshot
@@ -27,7 +27,7 @@
       become: true
       become_user: "{{ remote_regular_user }}"
       ansible.builtin.command:
-        cmd: "dconf read {{ gnome_custom_keybindings_base_path }}"
+        cmd: "dconf read {{ funcional_gnome_custom_keybindings_base_path }}"
       register: funcional_gnome_custom_keybindings_read
       changed_when: false
       failed_when: false
@@ -46,18 +46,18 @@
       become: true
       become_user: "{{ remote_regular_user }}"
       community.general.dconf:
-        key: "{{ gnome_custom_keybindings_base_path }}"
-        value: "{{ (funcional_gnome_custom_keybinding_paths + [gnome_flameshot_shortcut_path]) | unique | list }}"
+        key: "{{ funcional_gnome_custom_keybindings_base_path }}"
+        value: "{{ (funcional_gnome_custom_keybinding_paths + [funcional_gnome_flameshot_shortcut_path]) | unique | list }}"
         state: present
 
     - name: GNOME | Configurar claves del atajo personalizado de Flameshot
       become: true
       become_user: "{{ remote_regular_user }}"
       community.general.dconf:
-        key: "{{ gnome_flameshot_shortcut_path }}{{ item.key }}"
+        key: "{{ funcional_gnome_flameshot_shortcut_path }}{{ item.key }}"
         value: "{{ item.value }}"
         state: present
       loop:
-        - { key: "name", value: "'{{ gnome_flameshot_shortcut_name }}'" }
-        - { key: "command", value: "'{{ gnome_flameshot_shortcut_command }}'" }
-        - { key: "binding", value: "'{{ gnome_flameshot_shortcut_binding }}'" }
+        - { key: "name", value: "'{{ funcional_gnome_flameshot_shortcut_name }}'" }
+        - { key: "command", value: "'{{ funcional_gnome_flameshot_shortcut_command }}'" }
+        - { key: "binding", value: "'{{ funcional_gnome_flameshot_shortcut_binding }}'" }

--- a/roles/funcional/tasks/ui_performance.yml
+++ b/roles/funcional/tasks/ui_performance.yml
@@ -7,5 +7,5 @@
     key: "{{ item.key }}"
     value: "{{ item.value }}"
     state: present
-  loop: "{{ ui_performance_dconf_settings }}"
+  loop: "{{ funcional_ui_performance_dconf_settings }}"
   when: not (skip_gnome_tasks | default(false))

--- a/roles/funcional/vars/main.yml
+++ b/roles/funcional/vars/main.yml
@@ -1,25 +1,25 @@
 ---
 # Usuario genérico para ejecutar algunas tareas (con valor por defecto)
-remote_regular_user: "{{ ansible_env.SUDO_USER | default(ansible_user) }}"
+remote_regular_user: "{{ ansible_env.SUDO_USER | default(ansible_user) }}"  # noqa: var-naming[no-role-prefix]
 
 # INTERRUPTOR PRINCIPAL PARA EL ESTILO DE ESCRITORIOS VIRTUALES
 # Opciones válidas: 'dynamic' o 'fixed'
-gnome_workspace_style: "dynamic"
+funcional_gnome_workspace_style: "dynamic"
 
 # Red interna permitida para SSH (ajustar según entorno)
-internal_network: "192.168.0.0/16"
+funcional_internal_network: "192.168.0.0/16"
 
 # --- Configuración de DNS Públicos ---
 # DNS Primarios: Google
 # DNS Secundarios: Cloudflare
-sysadmin_public_dns_servers:
+funcional_public_dns_servers:
   - 8.8.8.8
   - 1.1.1.1
   - 8.8.4.4
   - 1.0.0.1
 
 # Listas de paquetes
-packages_system:
+funcional_packages_system:
   - htop
   - mc
   - tmux
@@ -33,14 +33,14 @@ packages_system:
   - locate
   - libxshmfence1
 
-packages_compression:
+funcional_packages_compression:
   - zip
   - gzip
   - tar
   - unzip
   - p7zip-full
 
-packages_apps:
+funcional_packages_apps:
   - poedit
   - fail2ban
   - ufw
@@ -48,7 +48,7 @@ packages_apps:
   - vlc
   - ffmpeg
 
-packages_hardware_analysis:
+funcional_packages_hardware_analysis:
   - inxi
   - hwinfo
   - glances
@@ -57,7 +57,7 @@ packages_hardware_analysis:
   - stacer
   - screenfetch
 
-packages_gui_utils:
+funcional_packages_gui_utils:
   - alacarte
   - fonts-firacode
   - flameshot
@@ -65,11 +65,11 @@ packages_gui_utils:
   - libpam-fprintd
   - fido2-tools
 
-packages_exclude_debian_13:
+funcional_packages_exclude_debian_13:
   - stacer
   - tldr
 
-packages_to_remove:
+funcional_packages_to_remove:
   - indicator-multiload
   - thunderbird
   - rhythmbox
@@ -80,7 +80,7 @@ packages_to_remove:
   - gnome-calendar
   - evolution
 
-python_for_functionals:
+funcional_python_for_functionals:
   - ipython3
   - python3-setuptools
   - python3-pip-whl
@@ -104,15 +104,15 @@ funcional_gnome_extensions_debian:
   - { id: 1160, uuid: "dash-to-panel@jderose9.github.com" }
 
 # Paquetes de idioma
-language_packs_debian:
+funcional_language_packs_debian:
   - task-spanish-desktop
   - task-english
 
 # Distribuciones de teclado a configurar en GNOME
-keyboard_layouts: |
+funcional_keyboard_layouts: |
   [('xkb', 'es'), ('xkb', 'us+alt-intl')]
 
-dconf_settings: >-
+funcional_dconf_settings: >-
   {{
     [
       { 'key': "/org/gnome/shell/extensions/wsmatrix/num-columns", 'value': "2" },
@@ -124,15 +124,15 @@ dconf_settings: >-
       { 'key': "/org/gnome/desktop/wm/preferences/button-layout", 'value': "':minimize,maximize,close'" },
       { 'key': "/org/gnome/desktop/interface/clock-show-date", 'value': "true" },
       { 'key': "/org/gnome/desktop/interface/show-battery-percentage", 'value': "true" },
-      { 'key': "/org/gnome/mutter/dynamic-workspaces", 'value': ('true' if gnome_workspace_style == 'dynamic' else 'false') }
+      { 'key': "/org/gnome/mutter/dynamic-workspaces", 'value': ('true' if funcional_gnome_workspace_style == 'dynamic' else 'false') }
     ]
     +
-    ([{ 'key': "/org/gnome/desktop/wm/preferences/num-workspaces", 'value': "4" }] if gnome_workspace_style == 'fixed' else [])
+    ([{ 'key': "/org/gnome/desktop/wm/preferences/num-workspaces", 'value': "4" }] if funcional_gnome_workspace_style == 'fixed' else [])
   }}
 
 # Atajos de teclado que se definen solo si el estilo es 'fixed'
-gnome_keybindings: >-
-  {% if gnome_workspace_style == 'fixed' %}
+funcional_gnome_keybindings: >-
+  {% if funcional_gnome_workspace_style == 'fixed' %}
   [
     { "key": "/org/gnome/desktop/wm/keybindings/move-to-workspace-1", "value": "['<Shift><Super>F1']" },
     { "key": "/org/gnome/desktop/wm/keybindings/move-to-workspace-2", "value": "['<Shift><Super>F2']" },
@@ -148,43 +148,43 @@ gnome_keybindings: >-
   {% endif %}
 
 # Atajo personalizado de GNOME para capturas con Flameshot
-gnome_custom_keybindings_base_path: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings"
-gnome_flameshot_shortcut_path: "{{ gnome_custom_keybindings_base_path }}/custom-flameshot/"
-gnome_flameshot_shortcut_name: "captura"
-gnome_flameshot_shortcut_command: "/usr/bin/flameshot gui"
-gnome_flameshot_shortcut_binding: "<Ctrl><Alt>s"
+funcional_gnome_custom_keybindings_base_path: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings"
+funcional_gnome_flameshot_shortcut_path: "{{ funcional_gnome_custom_keybindings_base_path }}/custom-flameshot/"
+funcional_gnome_flameshot_shortcut_name: "captura"
+funcional_gnome_flameshot_shortcut_command: "/usr/bin/flameshot gui"
+funcional_gnome_flameshot_shortcut_binding: "<Ctrl><Alt>s"
 
 # --- Configuración de Branding ---
-branding_wallpaper_light: ".wallpaper.png"
-branding_wallpaper_dark: ".wallpaper_dark.jpg"
+funcional_branding_wallpaper_light: ".wallpaper.png"
+funcional_branding_wallpaper_dark: ".wallpaper_dark.jpg"
 
 # Lista de archivos de branding para copiar al home del usuario
-branding_files_to_copy:
-  - { src: "wallpaper_2024.png", dest: "/home/{{ remote_regular_user }}/{{ branding_wallpaper_light }}" }
-  - { src: "wallpaper_dark_2024.jpg", dest: "/home/{{ remote_regular_user }}/{{ branding_wallpaper_dark }}" }
+funcional_branding_files_to_copy:
+  - { src: "wallpaper_2024.png", dest: "/home/{{ remote_regular_user }}/{{ funcional_branding_wallpaper_light }}" }
+  - { src: "wallpaper_dark_2024.jpg", dest: "/home/{{ remote_regular_user }}/{{ funcional_branding_wallpaper_dark }}" }
 
 # Lista de configuraciones de dconf para el fondo de pantalla y protector
-branding_dconf_settings:
-  - { key: "/org/gnome/desktop/background/picture-uri", value: "'file:///home/{{ remote_regular_user }}/{{ branding_wallpaper_light }}'" }
-  - { key: "/org/gnome/desktop/background/picture-uri-dark", value: "'file:///home/{{ remote_regular_user }}/{{ branding_wallpaper_dark }}'" }
-  - { key: "/org/gnome/desktop/screensaver/picture-uri", value: "'file:///home/{{ remote_regular_user }}/{{ branding_wallpaper_light }}'" }
+funcional_branding_dconf_settings:
+  - { key: "/org/gnome/desktop/background/picture-uri", value: "'file:///home/{{ remote_regular_user }}/{{ funcional_branding_wallpaper_light }}'" }
+  - { key: "/org/gnome/desktop/background/picture-uri-dark", value: "'file:///home/{{ remote_regular_user }}/{{ funcional_branding_wallpaper_dark }}'" }
+  - { key: "/org/gnome/desktop/screensaver/picture-uri", value: "'file:///home/{{ remote_regular_user }}/{{ funcional_branding_wallpaper_light }}'" }
   - { key: "/org/gnome/desktop/background/picture-options", value: "'zoom'" }
   - { key: "/org/gnome/desktop/background/primary-color", value: "'#d6d6d4'" }
 
 # Ajustes de dconf para mejorar el rendimiento y comportamiento de la UI
-ui_performance_dconf_settings:
+funcional_ui_performance_dconf_settings:
   - { key: "/org/gnome/desktop/interface/clock-show-seconds", value: "false" }
   - { key: "/org/gnome/desktop/interface/enable-animations", value: "false" }
   - { key: "/org/gnome/mutter/workspaces-only-on-primary", value: "true" }
 
 # Lista de aplicaciones favoritas para el dock de GNOME
-gnome_functional_favorite_apps: "['google-chrome.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Terminal.desktop', 'flameshot.desktop', 'streamsnap.desktop']"
+funcional_gnome_functional_favorite_apps: "['google-chrome.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Terminal.desktop', 'flameshot.desktop', 'streamsnap.desktop']"
 
 # Variable para controlar la reinstalación de Xorg
-force_xorg_reinstall: true # Cambiar a 'true' solo si es necesario depurar
+funcional_force_xorg_reinstall: true # Cambiar a 'true' solo si es necesario depurar
 
 # URLs y configuraciones de repositorios externos
-external_repos:
+funcional_external_repos:
   gcloud:
     gpg_url: "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
     repo_url: "https://packages.cloud.google.com/apt"
@@ -204,5 +204,5 @@ external_repos:
     github_url: "https://github.com/ingadhoc/adhoc-cli"
 
 # Timeouts para descargas
-download_timeout: 30
-apt_cache_valid_time: 3600 # 1 hora
+funcional_download_timeout: 30
+funcional_apt_cache_valid_time: 3600 # 1 hora

--- a/roles/sysadmin/molecule/default/verify.yml
+++ b/roles/sysadmin/molecule/default/verify.yml
@@ -5,7 +5,7 @@
   become: true
 
   vars_files:
-    - ../../vars.yml
+    - ../../vars/main.yml
 
   vars:
     sysadmin_remote_user: "{{ ansible_env.SUDO_USER | default('testuser') }}"

--- a/roles/sysadmin/tasks/fixes.yml
+++ b/roles/sysadmin/tasks/fixes.yml
@@ -16,7 +16,7 @@
 
     - name: Sysadmin | Instalar solo las extensiones de sysadmin que falten
       ansible.builtin.command: "code --install-extension {{ item }}"
-      loop: "{{ vscode_extension_list_sysadmin }}"
+      loop: "{{ sysadmin_vscode_extension_list }}"
       when: item not in sysadmin_installed_extensions.stdout_lines
       environment:
         DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/{{ remote_regular_user_uid }}/bus"

--- a/roles/sysadmin/tasks/main.yml
+++ b/roles/sysadmin/tasks/main.yml
@@ -1,8 +1,5 @@
 ---
-- name: Include vars
-  tags: always, sysadmin
-  ansible.builtin.include_vars: "{{ role_path }}/vars.yml"
-
+# Las variables del rol se cargan automáticamente desde vars/main.yml
 - name: Include
   block:
     - name: SysAdmin - Instalación de paquetes y dependencias varias

--- a/roles/sysadmin/tasks/nordvpn.yml
+++ b/roles/sysadmin/tasks/nordvpn.yml
@@ -58,7 +58,7 @@
     - name: NordVPN | Instalar el paquete de NordVPN
       ansible.builtin.apt:
         update_cache: true
-        cache_valid_time: "{{ 0 if (sysadmin_nordvpn_repo.changed | default(false)) else (apt_cache_valid_time | default(3600)) }}"
+        cache_valid_time: "{{ 0 if (sysadmin_nordvpn_repo.changed | default(false)) else (funcional_apt_cache_valid_time | default(3600)) }}"
         name: "{{ sysadmin_nordvpn_package }}"
         state: present
 

--- a/roles/sysadmin/vars/main.yml
+++ b/roles/sysadmin/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 # Usuario genérico para ejecutar algunas tareas
-remote_regular_user: "{{ ansible_env.SUDO_USER | default(ansible_user) }}"
-remote_regular_user_uid: "{{ ansible_env.SUDO_UID | default(ansible_user_uid) }}"
+remote_regular_user: "{{ ansible_env.SUDO_USER | default(ansible_user) }}"  # noqa: var-naming[no-role-prefix]
+remote_regular_user_uid: "{{ ansible_env.SUDO_UID | default(ansible_user_uid) }}"  # noqa: var-naming[no-role-prefix]
 
 # --- Configuración para Pulumi ---
 # Pulumi se instala como binario en /usr/local/bin/pulumi.
@@ -11,7 +11,7 @@ sysadmin_pulumi_version: "latest"
 sysadmin_pulumi_install_root: "/opt/pulumi"
 
 # Extensiones predefinidas para sysadmin
-vscode_extension_list_sysadmin:
+sysadmin_vscode_extension_list:
   # Container Tools
   - ms-azuretools.vscode-containers
   # Dev Containers

--- a/specifications.md
+++ b/specifications.md
@@ -60,7 +60,7 @@ seguir este patrón:
 7. Actualizar cache condicionalmente (`when: repo_added.changed`).
 
 Las URLs, claves y rutas de keyring de cada repo se centralizan en el
-`external_repos` de `vars.yml` del rol. Ver implementación de referencia en
+`funcional_external_repos` de `vars/main.yml` del rol. Ver implementación de referencia en
 `roles/funcional/tasks/kubectl.yml` y `gcloud.yml`.
 
 ### 3.2. Idempotencia Real vs Temporal
@@ -80,6 +80,13 @@ El código debe estar preparado para correr dentro de contenedores Docker durant
 
 - **VS Code Extensions:** La instalación de extensiones a veces provoca un crash de V8 al finalizar (return code `134`). Esto es esperado. Las tareas de VS Code deben aceptar `rc not in [0, 134]`.
 
+### 3.5. Variables y Nombres (vars/main.yml)
+
+- Las variables de cada rol viven en `roles/<rol>/vars/main.yml` (autocargado por Ansible), NUNCA hardcodeadas en los `tasks/*.yml`.
+- **Prefijo de rol obligatorio:** toda variable interna de un rol DEBE prefijarse con el nombre del rol (`funcional_packages_system`, `developer_docker_packages`, `sysadmin_kvm_packages`). Las variables de Ansible viven en un namespace global por play, así que el prefijo evita colisiones silenciosas entre roles y deja claro el origen (regla `var-naming[no-role-prefix]` de ansible-lint).
+- **Excepción — variables transversales:** `remote_regular_user` (y `remote_regular_user_uid`) son alias play-wide del usuario que se aprovisiona, compartidos a propósito entre todos los roles. NO se prefijan; se anotan con `# noqa: var-naming[no-role-prefix]` para documentar que es deliberado.
+- Roles que reutilizan tareas de otro rol sin heredarlo vía `meta` (ej. `deploy`, `freelance_developer`) cargan las vars del rol de origen con `include_vars` explícito, porque `import_tasks` con ruta relativa no las autocarga.
+
 ---
 
 ## 4. Testing Strategy (Molecule)
@@ -98,7 +105,7 @@ En lugar de correr el ciclo completo, para desarrollo se exige el flujo:
 
 1. **NO "Vibe Coding":** Antes de instalar un nuevo paquete o servicio, revisa este archivo. Aplica el patrón APT correspondiente si requiere un repositorio de terceros.
 2. **Linting estricto:** El proyecto usa pre-commit hooks (`yamllint`, `ansible-lint`). Escribe YAML canónico (sin abreviaturas raras de diccionarios, usando FQCN como `ansible.builtin.apt`).
-3. **Variables:** Las URLs de repositorios, GPG keys y listas de paquetes deben centralizarse en `vars.yml` del rol correspondiente, NUNCA hardcodeadas en los `tasks/main.yml`.
+3. **Variables:** Las URLs de repositorios, GPG keys y listas de paquetes deben centralizarse en `vars/main.yml` del rol correspondiente, NUNCA hardcodeadas en los `tasks/main.yml`.
 4. **Verificación:** Si agregas una herramienta (ej. `terraform`), DEBES agregar su correspondiente check de instalación y versión en `molecule/default/verify.yml`.
 5. **Changelog:** Todo cambio relevante al proyecto debe registrarse en `CHANGELOG.md` (raíz del repo) bajo la fecha del día. Se considera relevante cualquier cambio de comportamiento, nueva herramienta, decisión de arquitectura, o modificación de infraestructura de desarrollo (devcontainer, CI, tooling). No se registran correcciones de typos ni refactors internos sin impacto funcional.
 


### PR DESCRIPTION
## Qué

Migra la configuración de variables de los roles de `vars.yml` (cargado manualmente) a `vars/main.yml` (autocarga estándar de Ansible) y aplica prefijo de rol a las variables internas.

## Cambios

- **`vars.yml` → `vars/main.yml`** en los 4 roles. Se eliminaron los `include_vars` manuales de funcional/developer/sysadmin (ahora autocarga). Git lo detecta como rename → preserva historia.
- **Prefijo de rol** en ~28 vars internas de funcional (`funcional_packages_*`, `funcional_dconf_settings`, `funcional_branding_*`, `funcional_external_repos`, `funcional_gnome_*`…) + `sysadmin_vscode_extension_list`.
- **`remote_regular_user`** (transversal real, 76 refs) se mantiene **sin** prefijo con `# noqa` documentado — prefijarlo habría sido peor.
- `specifications.md` §3.5 documenta la convención para el futuro.
- devcontainer: agregado el feature `docker-outside-of-docker` (necesario para correr molecule).

## Validación

Molecule (create → converge → idempotence → verify → destroy), **exit 0** en todos:

| Rol | converge | idempotence | verify |
|-----|----------|-------------|--------|
| funcional | failed=0 | changed=0 | failed=0 |
| developer | failed=0 | changed=0 | failed=0 |
| sysadmin | failed=0 | changed=0 | failed=0 |
| freelance_developer | failed=0 | changed=0 | failed=0 |

- **deploy** (sin molecule): `include_vars` de `funcional/vars/main.yml` con tag `always` carga antes que las tareas kubectl/gcloud que usan `funcional_external_repos`; verificado con `--list-tasks` + syntax-check; 0 referencias al `vars.yml` viejo.
- ansible-lint `local.yml` limpio (profile production), syntax-check OK en los 4 perfiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
