### PR TITLE
docs: filtrado de CI por paths y branch protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Registro de cambios relevantes del proyecto. Formato basado en [Keep a Changelog
 - DevContainer: agregados los features `docker-outside-of-docker` (correr Molecule contra el daemon del host) y `github-cli` (gestionar PRs sin instalar `gh` manualmente)
 - `ansible-lint local.yml` pasa limpio a profile `production`; syntax-check OK en los 4 perfiles. Validado con `molecule test`: los 4 roles (funcional, developer, sysadmin, freelance_developer) pasan converge + idempotence (changed=0) + verify (exit 0)
 
+### CI/CD: filtrado por paths y branch protection
+
+- El workflow `molecule.yml` ahora filtra qué roles testear según los paths cambiados (`dorny/paths-filter`), respetando el grafo de dependencias: tocar `funcional` re-testea los 3 roles, `developer` re-testea developer+sysadmin, `sysadmin` solo sysadmin; cambios solo-docs no disparan ningún molecule (`lint` sí corre siempre). Evita correr los 3 molecule en cada cambio
+- El job `summary` trata `skipped` (rol sin cambios) como OK
+- Branch protection en `main`: requiere PR con 1 approval; required checks = `Lint Ansible code` y `Test Summary` (jobs que corren siempre), no los jobs por-rol (que se saltean). Documentado en `docs/TESTING.md`
+
 ### Limpieza de estructura: documentación, scripts y consistencia
 
 - **Documentación consolidada**: testing unificado en un único `docs/TESTING.md`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -247,11 +247,41 @@ extensiones de GNOME, VirtualBox y NordVPN (kernel modules).
 `.github/workflows/molecule.yml` corre en push/PR a `main`/`develop` y por
 `workflow_dispatch`:
 
-1. **lint** — `yamllint`, `ansible-lint` y `--syntax-check` (publica resumen en
-   el step summary).
-2. **test-funcional / test-developer / test-sysadmin** — `molecule test` por rol
-   en Debian 13, dependientes del job de lint. Ante fallo, suben un extracto del
-   log al summary.
+1. **changes** — `dorny/paths-filter` detecta qué cambió y decide qué roles
+   testear (ver más abajo).
+2. **lint** — `yamllint`, `ansible-lint` y `--syntax-check` (publica resumen en
+   el step summary). Corre **siempre**.
+3. **test-funcional / test-developer / test-sysadmin** — `molecule test` por rol
+   en Debian 13, dependientes de `lint` y gateados por `changes`. Ante fallo,
+   suben un extracto del log al summary.
+4. **summary** — agrega el resultado de los 3 roles. Trata `skipped` (rol sin
+   cambios) como OK; solo `failure`/`cancelled` marcan el pipeline como fallido.
+
+### Filtrado por paths (respeta el grafo de dependencias)
+
+Para no correr los 3 molecule en cada cambio (sobre todo en cambios solo-docs),
+cada test se gatea según los paths modificados. Como `developer` depende de
+`funcional` y `sysadmin` de `developer`, el filtro propaga la cascada:
+
+| Cambio en…           | Re-testea…                       |
+|----------------------|----------------------------------|
+| `roles/funcional/**` | funcional + developer + sysadmin |
+| `roles/developer/**` | developer + sysadmin             |
+| `roles/sysadmin/**`  | sysadmin                         |
+| `shared` (ver abajo) | los 3                            |
+| solo docs            | ninguno (igual corre `lint`)     |
+
+`shared` = archivos que afectan a todos los roles: `local.yml`,
+`collections/requirements.yml`, `requirements-dev.txt` y el propio
+`.github/workflows/molecule.yml`.
+
+### Branch protection (`main`)
+
+- Requiere PR con al menos **1 approval** (no se puede aprobar el PR propio).
+- Required status checks: **`Lint Ansible code`** y **`Test Summary`** — los dos
+  jobs que corren siempre. Los jobs por-rol **no** se marcan como required: como
+  se saltean cuando no hay cambios relevantes, un PR solo-docs los dejaría
+  eternamente pendientes. `Test Summary` ya refleja el resultado real de los 3.
 
 Para reproducir el pipeline localmente: `make ci` (lint + tests).
 


### PR DESCRIPTION
## Qué

Documentación de seguimiento del PR #22: el filtrado de CI por paths y la branch protection de `main` ya están vigentes, este PR los deja documentados.

## Cambios (solo docs)

- **`docs/TESTING.md`** — sección CI/CD ampliada:
  - Tabla del filtrado por rol respetando la cascada de dependencias (funcional→3 roles, developer→2, sysadmin→1, docs→0).
  - Config de branch protection de `main`: PR + 1 approval; required checks = `Lint Ansible code` y `Test Summary` (los que corren siempre), no los jobs por-rol (se saltean).
- **`CHANGELOG.md`** — nueva subsección CI/CD.

## Nota

Al ser un cambio solo-docs, este PR **no** dispara ningún molecule (lo valida el propio filtrado): solo corren `lint` y `summary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
