### PR TITLE
fix(readme): badge de Molecule CI mostraba 'no status'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto de Aprovisionamiento de Notebooks con Ansible
 
-![Molecule CI](https://github.com/ingadhoc/ansible_notebooks/workflows/Molecule%20CI/badge.svg?branch=main)
+[![Molecule CI](https://github.com/ingadhoc/ansible_notebooks/actions/workflows/molecule.yml/badge.svg?branch=main)](https://github.com/ingadhoc/ansible_notebooks/actions/workflows/molecule.yml)
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Ansible](https://img.shields.io/badge/ansible-%3E%3D2.15-blue.svg)
 ![Platforms](https://img.shields.io/badge/platforms-Debian%2013-blue.svg)


### PR DESCRIPTION
## Qué

El badge de Molecule CI en el README mostraba **"no status"** porque usaba el formato legacy `/workflows/<nombre>/badge.svg`, deprecado por GitHub.

## Fix

Migrado al formato actual que apunta al archivo del workflow:

- Antes: `…/workflows/Molecule%20CI/badge.svg?branch=main` → **no status**
- Ahora: `…/actions/workflows/molecule.yml/badge.svg?branch=main` → **passing** (verificado contra el endpoint)

Además el badge ahora enlaza a la página de runs del workflow.
