### PR TITLE
fix(roles): hacer idempotentes tareas que ocultaban cambios reales

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "1.10.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e",
+      "integrity": "sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e"
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ Registro de cambios relevantes del proyecto. Formato basado en [Keep a Changelog
 
 ## [2026-06-26]
 
+### Idempotencia: tareas que reportan sus cambios con veracidad
+
+- `sysadmin/helm.yml` y `sysadmin/nordvpn.yml`: el patrón "descargar a `/tmp` →
+  procesar → borrar temporal" reportaba `changed` en cada corrida y lo ocultaba con
+  `changed_when: false`. Ahora se gatea contra la existencia del artefacto final
+  (binario / keyring) con un `stat` previo, igual que el patrón ya usado en
+  `funcional/kubectl.yml`: en la segunda corrida no se ejecuta nada. Además
+  `shell` → `command` (sin features de shell; `gpg --dearmor -o`)
+- `funcional/user_sysadmin.yml`: quitado `changed_when: false` de la creación del
+  directorio de PolicyKit; el módulo `file` ya es idempotente y ahora reporta el
+  cambio real
+- `funcional/language.yml`: `localectl set-locale`/`set-x11-keymap` reportaban
+  siempre `ok` (`changed_when: false`) aunque cambiaran el sistema. Ahora el
+  `changed_when` se calcula contra `localectl status`. Se mantiene `failed_when:
+  false` (load-bearing: `localectl` puede no estar disponible sin systemd, y hay
+  fallback sobre `/etc/default/locale`), ahora documentado
+- `developer/code.yml`: `ignore_errors: true` → `failed_when: false` y guard del
+  loop con `| default([])`. Si `code --list-extensions` fallaba, se reinstalaban
+  **todas** las extensiones en vez de ninguna
+- Verificado: `ansible-lint` perfil `production` y `yamllint` limpios en los 5
+  archivos; `--syntax-check` OK. La idempotencia (`changed=0` en la segunda corrida)
+  la valida `molecule` en CI
+
 ### Variables: migración a `vars/main.yml` con prefijo de rol
 
 - Movidas las variables de cada rol de `roles/<rol>/vars.yml` (cargado vía `include_vars` manual) a `roles/<rol>/vars/main.yml` (autocarga estándar de Ansible). Eliminados los `include_vars` redundantes de funcional/developer/sysadmin

--- a/roles/developer/tasks/code.yml
+++ b/roles/developer/tasks/code.yml
@@ -83,12 +83,12 @@
         DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/{{ remote_regular_user_uid }}/bus"
       register: developer_installed_extensions
       changed_when: false
-      ignore_errors: true
+      failed_when: false
 
     - name: Code | Instalar solo las extensiones que falten
       ansible.builtin.command: "code --install-extension {{ item }}"
       loop: "{{ developer_vscode_extension_list }}"
-      when: item not in developer_installed_extensions.stdout_lines
+      when: item not in (developer_installed_extensions.stdout_lines | default([]))
       changed_when: true
 
 - name: Code | Gestionar la configuración del usuario

--- a/roles/developer/tasks/code.yml
+++ b/roles/developer/tasks/code.yml
@@ -88,7 +88,7 @@
     - name: Code | Instalar solo las extensiones que falten
       ansible.builtin.command: "code --install-extension {{ item }}"
       loop: "{{ developer_vscode_extension_list }}"
-      when: item not in (developer_installed_extensions.stdout_lines | default([]))
+      when: developer_installed_extensions.rc == 0 and item not in (developer_installed_extensions.stdout_lines | default([]))
       changed_when: true
 
 - name: Code | Gestionar la configuración del usuario

--- a/roles/funcional/tasks/language.yml
+++ b/roles/funcional/tasks/language.yml
@@ -13,11 +13,21 @@
         name: es_ES.UTF-8
         state: present
 
+    - name: Idiomas | Consultar la configuración regional actual del sistema
+      ansible.builtin.command: localectl status
+      register: funcional_localectl_status
+      changed_when: false
+      failed_when: false
+
     - name: Idiomas | Establecer la configuración regional (locale) del sistema
       ansible.builtin.command: "localectl set-locale LANG=es_ES.UTF-8"
-      changed_when: false
       register: funcional_localectl_result
+      # localectl puede no estar disponible en entornos sin systemd (ej. contenedores):
+      # no fallamos y caemos al fallback sobre /etc/default/locale.
       failed_when: false
+      changed_when: >-
+        funcional_localectl_result.rc == 0
+        and 'LANG=es_ES.UTF-8' not in funcional_localectl_status.stdout
 
     - name: Idiomas | Establecer locale via /etc/default/locale (fallback)
       ansible.builtin.lineinfile:
@@ -30,8 +40,12 @@
 
     - name: Idiomas | Establecer las distribuciones de teclado del sistema (X11)
       ansible.builtin.command: "localectl set-x11-keymap es,us pc105 ,alt-intl"
-      changed_when: false
+      register: funcional_x11keymap_result
+      # Igual que el locale: localectl puede no estar disponible sin systemd.
       failed_when: false
+      changed_when: >-
+        funcional_x11keymap_result.rc == 0
+        and 'X11 Layout: es,us' not in funcional_localectl_status.stdout
 
     - name: Idiomas | Configurar las distribuciones de teclado para la sesión del usuario (GNOME)
       become: true

--- a/roles/funcional/tasks/user_sysadmin.yml
+++ b/roles/funcional/tasks/user_sysadmin.yml
@@ -62,7 +62,6 @@
         owner: root
         group: root
         mode: "0755"
-      changed_when: false
 
     - name: SysAdmin | Prevenir que 'sysadmin' sea usado para autenticación gráfica
       ansible.builtin.copy:

--- a/roles/sysadmin/tasks/helm.yml
+++ b/roles/sysadmin/tasks/helm.yml
@@ -3,27 +3,34 @@
 - name: SysAdmin - Install helm cli
   tags: helm_cli
   block:
+    - name: Helm | Verificar si el binario de helm ya está instalado
+      become: true
+      ansible.builtin.stat:
+        path: /usr/local/bin/helm
+      register: sysadmin_helm_bin
+
     - name: Helm | Descargar script de instalación
       become: true
       ansible.builtin.get_url:
         url: https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
         dest: /tmp/get_helm.sh
         mode: "0755"
-      changed_when: false
+      when: not sysadmin_helm_bin.stat.exists
 
     - name: Helm | Ejecutar script de instalación si no existe el binario
       become: true
-      ansible.builtin.shell: bash /tmp/get_helm.sh
+      ansible.builtin.command: bash /tmp/get_helm.sh
       args:
         creates: /usr/local/bin/helm
-        executable: /bin/bash
+      when: not sysadmin_helm_bin.stat.exists
+      changed_when: true
 
     - name: Helm | Limpiar el script de instalación
       become: true
       ansible.builtin.file:
         path: /tmp/get_helm.sh
         state: absent
-      changed_when: false
+      when: not sysadmin_helm_bin.stat.exists
 
     - name: Helm | Configurar autocompletado de bash para el usuario
       ansible.builtin.blockinfile:

--- a/roles/sysadmin/tasks/nordvpn.yml
+++ b/roles/sysadmin/tasks/nordvpn.yml
@@ -5,25 +5,30 @@
   become: true
   when: not (sysadmin_skip_nordvpn | default(false))
   block:
+    - name: NordVPN | Verificar si la clave GPG del repositorio ya existe
+      ansible.builtin.stat:
+        path: "{{ sysadmin_nordvpn_gpg_path }}"
+      register: sysadmin_nordvpn_gpg_key
+
     - name: NordVPN | Descargar la clave GPG del repositorio de NordVPN
       ansible.builtin.get_url:
         url: https://repo.nordvpn.com/gpg/nordvpn_public.asc
         dest: /tmp/nordvpn_public.asc
         mode: "0644"
-      changed_when: false
+      when: not sysadmin_nordvpn_gpg_key.stat.exists
 
-    - name: NordVPN | Convertir y mover la clave GPG
-      ansible.builtin.shell: gpg --dearmor < /tmp/nordvpn_public.asc > {{ sysadmin_nordvpn_gpg_path }}
+    - name: NordVPN | Convertir y guardar la clave GPG
+      ansible.builtin.command: gpg --dearmor -o {{ sysadmin_nordvpn_gpg_path }} /tmp/nordvpn_public.asc
       args:
         creates: "{{ sysadmin_nordvpn_gpg_path }}"
-        executable: /bin/bash
-      changed_when: false
+      when: not sysadmin_nordvpn_gpg_key.stat.exists
+      changed_when: true
 
     - name: NordVPN | Limpiar archivo temporal de clave GPG
       ansible.builtin.file:
         path: /tmp/nordvpn_public.asc
         state: absent
-      changed_when: false
+      when: not sysadmin_nordvpn_gpg_key.stat.exists
 
     # El paquete nordvpn autogestiona su propio archivo de repo vía postinst.
     # Configuramos el repo solo como bootstrap cuando aún no está instalado;


### PR DESCRIPTION
Varias tareas usaban changed_when:false (y un ignore_errors) para silenciar no-idempotencia o errores, en vez de reportar el estado real:

- sysadmin/helm.yml, sysadmin/nordvpn.yml: el patron descargar->procesar->borrar temporal reportaba changed siempre. Se gatea contra el artefacto final con un stat previo (mismo patron que funcional/kubectl.yml). shell -> command.
- funcional/user_sysadmin.yml: quitado changed_when:false de un mkdir idempotente.
- funcional/language.yml: changed_when veraz en localectl via 'localectl status'; failed_when:false conservado (fallback sin systemd) y documentado.
- developer/code.yml: ignore_errors -> failed_when:false + default([]) en el guard del loop (evita reinstalar todas las extensiones si falla el listado).

Lint (production) + yamllint + syntax-check OK. Idempotencia validada por molecule en CI.