### PR TITLE
refactor(wine-microsip): eliminar update_cache redundante tras add-architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ Registro de cambios relevantes del proyecto. Formato basado en [Keep a Changelog
 
 - `funcional/wine-microsip.yml`:
   - `dpkg --add-architecture i386` reportaba `changed` en cada corrida. Ahora se
-    gatea contra `dpkg --print-foreign-architectures`, y el `apt update_cache`
-    posterior solo corre si recién se agregó la arquitectura
+    gatea contra `dpkg --print-foreign-architectures`. El `apt update_cache` que
+    venía después se eliminó por redundante: el refresco del repo WineHQ
+    (`cache_valid_time: 0`) ya corre con i386 habilitado y cubre las variantes
+    `:i386` (esto quita además un `# noqa: no-handler`)
   - el `get_url` de MicroSIP usaba `force: true`, re-descargando el instalador en
     cada corrida aunque ya estuviera instalado. Ahora se gatea (junto con el
     install) contra un `stat` del `.exe` final

--- a/roles/funcional/tasks/wine-microsip.yml
+++ b/roles/funcional/tasks/wine-microsip.yml
@@ -12,40 +12,34 @@
     - name: Wine & MicroSIP | Enable 32-bit architecture support
       ansible.builtin.command: dpkg --add-architecture i386
       when: "'i386' not in funcional_foreign_arch.stdout_lines"
-      register: funcional_add_arch_result
       changed_when: true
 
-    # ===== 2. Actualizar cache APT tras habilitar i386 =====
-    # Solo si recién agregamos i386: si ya estaba, el índice no cambió.
-    - name: Wine & MicroSIP | Update APT cache after enabling i386  # noqa: no-handler
-      ansible.builtin.apt:
-        update_cache: true
-      when: funcional_add_arch_result is changed
-
-    # ===== 3. Crear directorio de keyrings =====
+    # ===== 2. Crear directorio de keyrings =====
     - name: Wine & MicroSIP | Create keyring directory
       ansible.builtin.file:
         path: /etc/apt/keyrings
         state: directory
         mode: "0755"
 
-    # ===== 4. Descargar clave GPG WineHQ =====
+    # ===== 3. Descargar clave GPG WineHQ =====
     - name: Wine & MicroSIP | Download WineHQ GPG key
       ansible.builtin.get_url:
         url: https://dl.winehq.org/wine-builds/winehq.key
         dest: /etc/apt/keyrings/winehq-archive.key
         mode: "0644"
 
-    # ===== 5. Descargar archivo .sources de WineHQ para Trixie =====
+    # ===== 4. Descargar archivo .sources de WineHQ para Trixie =====
     - name: Wine & MicroSIP | Download WineHQ Trixie sources file
       ansible.builtin.get_url:
         url: https://dl.winehq.org/wine-builds/debian/dists/trixie/winehq-trixie.sources
         dest: /etc/apt/sources.list.d/winehq-trixie.sources
         mode: "0644"
 
-    # ===== 6. Actualizar cache APT con repo WineHQ =====
+    # ===== 5. Actualizar cache APT con repo WineHQ =====
     # cache_valid_time: 0 fuerza el refresco real del índice (evita que APT
     # considere válida una caché previa y deje el repo WineHQ sin indexar).
+    # Este refresco corre con i386 ya habilitado, así que cubre también las
+    # variantes :i386 (no hace falta un update extra tras add-architecture).
     # Reintentos por si el mirror de WineHQ responde lento/intermitente.
     - name: Wine & MicroSIP | Update APT cache after adding WineHQ repo
       ansible.builtin.apt:
@@ -56,7 +50,7 @@
       retries: 3
       delay: 5
 
-    # ===== 7. Instalar Wine estable =====
+    # ===== 6. Instalar Wine estable =====
     # update_cache: true dentro de la misma tarea garantiza que el índice se
     # refresque inmediatamente antes de resolver el paquete (cierra la ventana
     # de carrera donde winehq-stable aún no era visible). until/retries cubre
@@ -73,13 +67,13 @@
       retries: 3
       delay: 10
 
-    # ===== 8. Instalar xvfb para instalaciones headless =====
+    # ===== 7. Instalar xvfb para instalaciones headless =====
     - name: Wine & MicroSIP | Install xvfb for headless Wine operations
       ansible.builtin.apt:
         name: xvfb
         state: present
 
-    # ===== 9. Inicializar Wine prefix (headless, sin GUI) =====
+    # ===== 8. Inicializar Wine prefix (headless, sin GUI) =====
     - name: Wine & MicroSIP | Initialize Wine prefix
       become: true
       become_user: "{{ remote_regular_user }}"
@@ -94,7 +88,7 @@
         HOME: "/home/{{ remote_regular_user }}"
         WINEARCH: win64
 
-    # ===== 10. Descargar MicroSIP =====
+    # ===== 9. Descargar MicroSIP =====
     # Gateamos descarga e instalación contra el .exe final: si MicroSIP ya está
     # instalado no re-descargamos (antes force:true bajaba el instalador siempre).
     - name: Wine & MicroSIP | Verificar si MicroSIP ya está instalado
@@ -112,7 +106,7 @@
           User-Agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
       when: not funcional_microsip_installed.stat.exists
 
-    # ===== 11. Instalar MicroSIP con Wine (headless, silenciosa) =====
+    # ===== 10. Instalar MicroSIP con Wine (headless, silenciosa) =====
     - name: Wine & MicroSIP | Install MicroSIP via Wine
       become: true
       become_user: "{{ remote_regular_user }}"
@@ -130,7 +124,7 @@
         WINEDEBUG: "-all"
         DISPLAY: ":99"
 
-    # ===== 12. Crear directorio de aplicaciones de escritorio =====
+    # ===== 11. Crear directorio de aplicaciones de escritorio =====
     - name: Wine & MicroSIP | Create applications directory
       ansible.builtin.file:
         path: "/home/{{ remote_regular_user }}/.local/share/applications"
@@ -139,7 +133,7 @@
         group: "{{ remote_regular_user }}"
         mode: "0755"
 
-    # ===== 13. Crear acceso directo de escritorio =====
+    # ===== 12. Crear acceso directo de escritorio =====
     - name: Wine & MicroSIP | Create MicroSIP desktop entry
       ansible.builtin.copy:
         content: |
@@ -154,7 +148,7 @@
         mode: "0644"
       register: funcional_microsip_desktop_entry
 
-    # ===== 14. Actualizar base de datos de aplicaciones =====
+    # ===== 13. Actualizar base de datos de aplicaciones =====
     # Solo si el .desktop cambió: refrescar la base si no cambió nada reportaba
     # changed en cada corrida.
     - name: Wine & MicroSIP | Update desktop database  # noqa: no-handler


### PR DESCRIPTION
Follow-up de #27.

La tarea *"Update APT cache after enabling i386"* era **redundante**: entre habilitar i386 y el primer `apt install` (winehq-stable) solo hay tareas `file`/`get_url`, y el refresco del repo WineHQ (`cache_valid_time: 0`) ya corre con i386 habilitado, cubriendo las variantes `:i386`.

## Cambios
- Eliminada la tarea redundante (en vez de gatearla con `changed_when` + `# noqa`).
- Quitado el `# noqa: no-handler` asociado — alineado con la convención del repo para `no-handler` (reestructurar, no `noqa`; ver CHANGELOG 2026-06-25).
- Quitado el `register: funcional_add_arch_result`, ya sin uso.
- Renumerados los comentarios de pasos (`# ===== N. =====`) para no dejar hueco.

## Verificación
- `ansible-lint` perfil **production** y `yamllint`: limpios.
- `ansible-playbook --syntax-check local.yml`: OK.
- Idempotencia: la valida `molecule` en CI.

> Nota: queda un `# noqa: no-handler` en *"Update desktop database"*, que es legítimo (comando que debe correr tras cambiar el `.desktop`, sin tarea apt donde fusionarlo).