### PR TITLE
fix(developer): dearmor GPG con changed_when veraz + quitar stat muertos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ Registro de cambios relevantes del proyecto. Formato basado en [Keep a Changelog
 
 ## [2026-06-26]
 
+### Idempotencia: auditoría de roles (dearmor GPG + código muerto)
+
+- `developer/docker.yml` y `developer/code.yml`: el `gpg --dearmor` (gateado por un
+  `stat` previo de la clave) usaba `changed_when: false`, así que cuando creaba el
+  keyring en la primera instalación reportaba `ok` en vez de `changed`. Cambiado a
+  `changed_when: true`, alineándolos con el mismo patrón ya correcto en
+  `funcional/browsers.yml`, `funcional/adhoccli.yml` y `funcional/gcloud.yml`
+- `developer/prepare_remote_dev.yml`: eliminadas 4 tareas `stat`
+  (`developer_ctx_dir`, `developer_16_dir`, `developer_18_dir`, `developer_19_dir`)
+  cuyos registros no se usaban en ningún `when` — código muerto. El módulo `git`
+  con `update: true` ya hace clone-or-update idempotente
+- Auditados además awscli, pulumi, kvm, shortcuts, python, browsers, adhoccli,
+  gnome, gcloud, local_dns y los `fixes` de developer/funcional: sin hallazgos
+  (módulos idempotentes, `changed_when`/`creates`/`stat` correctos). Cross-check de
+  `notify` → todos apuntan a handlers existentes
+- Verificado: `ansible-lint` perfil `production` y `yamllint` limpios; `--syntax-check`
+  OK. La idempotencia (`changed=0` en la segunda corrida) la valida `molecule` en CI
+
 ### Idempotencia: wine-microsip y extensiones de VS Code (sysadmin)
 
 - `funcional/wine-microsip.yml`:

--- a/roles/developer/tasks/code.yml
+++ b/roles/developer/tasks/code.yml
@@ -24,8 +24,10 @@
     - name: Code | Convertir y guardar la clave GPG
       ansible.builtin.command: >-
         gpg --dearmor -o {{ developer_external_repos.vscode.keyring_path }} /tmp/microsoft.asc
+      # Solo corre si la clave no existía (gateado por el stat de arriba): cuando
+      # corre, crea el keyring, así que el cambio es real (igual que browsers/adhoccli).
       when: not developer_vscode_gpg_key.stat.exists
-      changed_when: false
+      changed_when: true
 
     - name: Code | Limpiar archivo temporal
       ansible.builtin.file:

--- a/roles/developer/tasks/docker.yml
+++ b/roles/developer/tasks/docker.yml
@@ -30,8 +30,10 @@
     - name: Docker | Convertir la clave GPG al formato requerido
       ansible.builtin.command: >-
         gpg --dearmor -o {{ developer_external_repos.docker.keyring_path }} /tmp/docker.gpg
+      # Solo corre si la clave no existía (gateado por el stat de arriba): cuando
+      # corre, crea el keyring, así que el cambio es real.
       when: not developer_docker_gpg_key.stat.exists
-      changed_when: false
+      changed_when: true
 
     - name: Docker | Limpiar archivo temporal de clave GPG
       ansible.builtin.file:

--- a/roles/developer/tasks/prepare_remote_dev.yml
+++ b/roles/developer/tasks/prepare_remote_dev.yml
@@ -13,11 +13,8 @@
         state: directory
         mode: "0755"
 
-    - name: Odoo Dev | Verificar si el directorio ctx existe
-      ansible.builtin.stat:
-        path: "{{ developer_odoo_base_path }}/ctx"
-      register: developer_ctx_dir
-
+    # git con update: true ya hace clone-or-update idempotente; no hace falta
+    # un stat previo (los registros que había no se usaban en ningún when).
     - name: Odoo Dev | Clonar/actualizar repositorio docker-compose-context a 'ctx'
       ansible.builtin.git:
         repo: "{{ developer_odoo_ctx_repo }}"
@@ -26,11 +23,6 @@
         accept_hostkey: true
         update: true
         force: true
-
-    - name: Odoo Dev | Verificar si el directorio 16 existe
-      ansible.builtin.stat:
-        path: "{{ developer_odoo_base_path }}/16"
-      register: developer_16_dir
 
     - name: Odoo Dev | Clonar/actualizar repositorio docker-compose-odoo a '16'
       ansible.builtin.git:
@@ -41,11 +33,6 @@
         update: true
         force: true
 
-    - name: Odoo Dev | Verificar si el directorio 18 existe
-      ansible.builtin.stat:
-        path: "{{ developer_odoo_base_path }}/18"
-      register: developer_18_dir
-
     - name: Odoo Dev | Clonar/actualizar repositorio docker-compose-odoo a '18'
       ansible.builtin.git:
         repo: "{{ developer_odoo_main_repo }}"
@@ -54,11 +41,6 @@
         accept_hostkey: true
         update: true
         force: true
-
-    - name: Odoo Dev | Verificar si el directorio 19 existe
-      ansible.builtin.stat:
-        path: "{{ developer_odoo_base_path }}/19"
-      register: developer_19_dir
 
     - name: Odoo Dev | Clonar/actualizar repositorio docker-compose-odoo a '19'
       ansible.builtin.git:


### PR DESCRIPTION
Auditoría de idempotencia sobre los roles (puntos 1 y 2 de la revisión).

## Punto 1 — `gpg --dearmor` con `changed_when` veraz
`developer/docker.yml` y `developer/code.yml` tenían el dearmor (gateado por un `stat` previo de la clave) con `changed_when: false`. Cuando creaba el keyring en la primera instalación, reportaba `ok` en vez de `changed`.

→ `changed_when: true`, **alineándolos con el patrón ya correcto** en `funcional/browsers.yml`, `funcional/adhoccli.yml` y `funcional/gcloud.yml` (los únicos dos outliers del repo eran estos).

## Punto 2 — código muerto en `prepare_remote_dev.yml`
4 tareas `stat` (`developer_ctx_dir`, `developer_16_dir`, `developer_18_dir`, `developer_19_dir`) registraban variables que **no se usaban en ningún `when`**. El módulo `git` con `update: true` ya hace clone-or-update idempotente. Eliminadas.

## Resto del audit — sin hallazgos
Revisados además: `awscli`, `pulumi`, `kvm`, `shortcuts`, `python`, `browsers`, `adhoccli`, `gnome`, `gcloud`, `local_dns` y los `fixes` de developer/funcional. Módulos idempotentes, `changed_when`/`creates`/`stat` correctos. Cross-check de `notify` → todos apuntan a handlers existentes.

> Nota: el `force: true` de `awscli.yml` (get_url) está gateado por `when: rc != 0 or force_update`, así que solo baja cuando reinstala — no es un smell.

## Verificación
- `ansible-lint` perfil **production** y `yamllint`: limpios.
- `ansible-playbook --syntax-check local.yml`: OK.
- Idempotencia: la valida `molecule` en CI (toca `developer` → re-testea developer+sysadmin).