### PR TITLE
docs(spec): convención de idempotencia (stat-gate + changed_when veraz)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Registro de cambios relevantes del proyecto. Formato basado en [Keep a Changelog
 
 ## [2026-06-26]
 
+### Docs: convención de idempotencia en `specifications.md`
+
+- Reescrita la §3.2 ("Idempotencia Real vs Temporal"): la redacción anterior
+  (`DEBE usar changed_when: false` para temporales) habilitaba justo el smell que
+  veníamos corrigiendo. Ahora documenta el patrón real — `changed_when: false` solo
+  para lecturas/limpiezas, patrón "stat-gate" + `changed_when: true` para comandos
+  que crean artefactos, `changed_when` calculado cuando la salida indica el cambio,
+  y prohibición explícita de enmascarar no-idempotencia
+
 ### Idempotencia: auditoría de roles (dearmor GPG + código muerto)
 
 - `developer/docker.yml` y `developer/code.yml`: el `gpg --dearmor` (gateado por un

--- a/specifications.md
+++ b/specifications.md
@@ -78,12 +78,13 @@ veracidad** — ni mentir que no cambiaron, ni reportar `changed` cuando no hubo
   previo del artefacto final + `when: not <artefacto>.stat.exists` +
   `changed_when: true` (o el arg `creates:`). En la segunda corrida el `when`
   saltea la tarea, así que da `changed=0` sin haber mentido en la primera.
-  Referencia: `gpg --dearmor` en `browsers.yml`/`gcloud.yml`; descarga→instalación
-  de binarios en `kubectl.yml`/`helm.yml`.
+  Referencia: `gpg --dearmor` en `roles/funcional/tasks/browsers.yml` /
+  `roles/funcional/tasks/gcloud.yml`; descarga→instalación de binarios en
+  `roles/funcional/tasks/kubectl.yml` / `roles/sysadmin/tasks/helm.yml`.
 - **Comando cuya salida indica si cambió → `changed_when` calculado:** evaluar el
   resultado real, p.ej. `changed_when: "'already installed' not in result.stdout"`
   (VS Code), o comparar contra una consulta previa (`localectl status` antes de
-  `set-locale` en `language.yml`).
+  `set-locale` en `roles/funcional/tasks/language.yml`).
 - **Prohibido usar `changed_when: false` para enmascarar no-idempotencia.** Si una
   tarea reportaría `changed` en cada corrida (ej. descargar→procesar→borrar un
   temporal, `dpkg --add-architecture`), hay que **gatearla** contra el estado final,

--- a/specifications.md
+++ b/specifications.md
@@ -65,8 +65,32 @@ Las URLs, claves y rutas de keyring de cada repo se centralizan en el
 
 ### 3.2. Idempotencia Real vs Temporal
 
-- Si una tarea manipula archivos temporales o hace limpiezas que no alteran el estado funcional del sistema, DEBE usar `changed_when: false`.
-- La idempotencia se valida evaluando el estado final del sistema (ej. si el binario está instalado), no en los pasos intermedios de descarga.
+La idempotencia se valida por el **estado final** del sistema (¿está el binario /
+keyring / archivo?), no por los pasos intermedios de descarga. Una segunda corrida
+del playbook DEBE dar `changed=0`. Las tareas deben reportar su cambio **con
+veracidad** — ni mentir que no cambiaron, ni reportar `changed` cuando no hubo cambio:
+
+- **`changed_when: false` SOLO para tareas sin efecto sobre el estado funcional:**
+  lecturas/consultas (`stat`, `dpkg --print-foreign-architectures`,
+  `localectl status`, `code --list-extensions`) y limpiezas de `/tmp`. NUNCA en una
+  tarea que crea o modifica un artefacto real.
+- **Comando imperativo que crea un artefacto → patrón "stat-gate":** un `stat`
+  previo del artefacto final + `when: not <artefacto>.stat.exists` +
+  `changed_when: true` (o el arg `creates:`). En la segunda corrida el `when`
+  saltea la tarea, así que da `changed=0` sin haber mentido en la primera.
+  Referencia: `gpg --dearmor` en `browsers.yml`/`gcloud.yml`; descarga→instalación
+  de binarios en `kubectl.yml`/`helm.yml`.
+- **Comando cuya salida indica si cambió → `changed_when` calculado:** evaluar el
+  resultado real, p.ej. `changed_when: "'already installed' not in result.stdout"`
+  (VS Code), o comparar contra una consulta previa (`localectl status` antes de
+  `set-locale` en `language.yml`).
+- **Prohibido usar `changed_when: false` para enmascarar no-idempotencia.** Si una
+  tarea reportaría `changed` en cada corrida (ej. descargar→procesar→borrar un
+  temporal, `dpkg --add-architecture`), hay que **gatearla** contra el estado final,
+  no silenciarla.
+- `failed_when: false` es aceptable solo cuando el fallo es esperado y hay fallback,
+  documentado en un comentario (p.ej. `localectl` sin systemd → fallback a
+  `/etc/default/locale`).
 
 ### 3.3. Entornos Docker y Restricciones (Para Molecule)
 
@@ -110,4 +134,4 @@ En lugar de correr el ciclo completo, para desarrollo se exige el flujo:
 5. **Changelog:** Todo cambio relevante al proyecto debe registrarse en `CHANGELOG.md` (raíz del repo) bajo la fecha del día. Se considera relevante cualquier cambio de comportamiento, nueva herramienta, decisión de arquitectura, o modificación de infraestructura de desarrollo (devcontainer, CI, tooling). No se registran correcciones de typos ni refactors internos sin impacto funcional.
 
 ---
-*Última actualización: Marzo 2026. Documento "Spec-Anchored" para el proyecto Ansible Notebooks de Adhoc.*
+*Última actualización: Junio 2026. Documento "Spec-Anchored" para el proyecto Ansible Notebooks de Adhoc.*


### PR DESCRIPTION
Reescribe la §3.2 de `specifications.md` para documentar la convención de idempotencia que venimos aplicando (#25/#27/#29).

La redacción anterior (`DEBE usar changed_when: false` para tareas con temporales) habilitaba justo el smell corregido. La nueva:

- `changed_when: false` **solo** para lecturas/consultas y limpiezas de `/tmp`.
- Patrón **stat-gate** (`stat` previo + `when: not exists` + `changed_when: true`) para comandos que crean artefactos.
- `changed_when` **calculado** cuando la salida del comando indica si cambió.
- Prohibición explícita de enmascarar no-idempotencia.
- `failed_when: false` solo con fallback documentado.

Solo docs → el path-filter no dispara molecule (corre lint nomás).