### PR TITLE
refactor(funcional): helper deb822 reutilizable (PoC en adhoccli)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ Registro de cambios relevantes del proyecto. Formato basado en [Keep a Changelog
 
 ## [2026-06-26]
 
+### Refactor (PoC): helper reutilizable para repos deb822
+
+- Nuevo `roles/funcional/tasks/_setup_apt_repo.yml` + template
+  `roles/funcional/templates/deb822.sources.j2`: centralizan el patrón "keyring GPG +
+  repo deb822" (§3.1) que estaba duplicado ~7 veces (docker, code, gh_cli, browsers,
+  gcloud, kubectl, nordvpn, adhoccli). Toma una entrada de `*_external_repos` y arma
+  keyring + `.sources`; el caller solo instala los paquetes y gatea el `update_cache`
+  con `_repo_sources.changed`
+- Migrado `funcional/adhoccli.yml` como **prueba de concepto** (68 → 25 líneas). Vars
+  de adhoccli normalizadas a campos estructurados deb822 (`uris`/`suites`/`components`/
+  `filename`); la salida del `.sources` es byte-idéntica a la anterior
+- Pendiente (si se valida el PoC): migrar los repos restantes y resolver el acceso
+  cross-rol al helper (developer/sysadmin lo consumirían vía `include_role` +
+  `tasks_from`, sin re-ejecutar el rol funcional)
+- Verificado: `ansible-lint` perfil `production` y `yamllint` limpios; `--syntax-check`
+  OK. El `verify` de molecule de funcional ya chequea el keyring y el `.sources` de adhoc
+
 ### Idempotencia: auditoría de roles (dearmor GPG + código muerto)
 
 - `developer/docker.yml` y `developer/code.yml`: el `gpg --dearmor` (gateado por un

--- a/roles/funcional/tasks/_setup_apt_repo.yml
+++ b/roles/funcional/tasks/_setup_apt_repo.yml
@@ -15,8 +15,9 @@
 #     - architectures (opcional) deb822 Architectures
 #
 # Salida:
-#   _repo_sources: resultado del template del .sources. Usar `_repo_sources.changed`
-#   para gatear el `update_cache` del install posterior en el caller.
+#   _repo_sources: resultado del template del .sources. El caller usa
+#   `_repo_sources.changed` para forzar el refresh del índice (`cache_valid_time: 0`)
+#   en su tarea de install solo cuando el repo cambió.
 #
 # Nota: los registros van con # noqa var-naming porque este helper es transversal
 # a varios roles; no aplica un prefijo de rol único.
@@ -43,8 +44,13 @@
   when: not _repo_keyring.stat.exists
 
 - name: "Repo deb822 | Convertir la llave a keyring/dearmor ({{ _repo.filename }})"
-  ansible.builtin.command: >-
-    gpg --dearmor -o {{ _repo.keyring_path }} /tmp/{{ _repo.filename }}-apt-key.tmp
+  ansible.builtin.command:
+    argv:
+      - gpg
+      - --dearmor
+      - -o
+      - "{{ _repo.keyring_path }}"
+      - "/tmp/{{ _repo.filename }}-apt-key.tmp"
   # Gateado por el stat: cuando corre, crea el keyring → el cambio es real.
   when: not _repo_keyring.stat.exists
   changed_when: true

--- a/roles/funcional/tasks/_setup_apt_repo.yml
+++ b/roles/funcional/tasks/_setup_apt_repo.yml
@@ -1,0 +1,70 @@
+---
+# Helper reutilizable: instala el keyring GPG y el repositorio deb822 (.sources)
+# de un repo externo. Centraliza el patrón de §3.1 (specifications.md), antes
+# duplicado en cada tarea de repo (docker, code, browsers, gcloud, kubectl...).
+#
+# Entrada (vars):
+#   _repo: una entrada de *_external_repos con las claves:
+#     - gpg_url       URL de la llave GPG (armada / .asc)
+#     - keyring_path  destino del keyring dearmado
+#     - uris          URI del repo (deb822 URIs)
+#     - suites        deb822 Suites
+#     - components    deb822 Components
+#     - filename      base del archivo en sources.list.d (sin extensión) y del
+#                     temporal de la llave
+#     - architectures (opcional) deb822 Architectures
+#
+# Salida:
+#   _repo_sources: resultado del template del .sources. Usar `_repo_sources.changed`
+#   para gatear el `update_cache` del install posterior en el caller.
+#
+# Nota: los registros van con # noqa var-naming porque este helper es transversal
+# a varios roles; no aplica un prefijo de rol único.
+- name: "Repo deb822 | Asegurar el directorio del keyring ({{ _repo.filename }})"
+  ansible.builtin.file:
+    path: "{{ _repo.keyring_path | dirname }}"
+    state: directory
+    mode: "0755"
+
+- name: "Repo deb822 | Verificar si la llave GPG ya existe ({{ _repo.filename }})"
+  ansible.builtin.stat:
+    path: "{{ _repo.keyring_path }}"
+  register: _repo_keyring  # noqa: var-naming[no-role-prefix]
+
+- name: "Repo deb822 | Descargar la llave GPG ({{ _repo.filename }})"
+  ansible.builtin.get_url:
+    url: "{{ _repo.gpg_url }}"
+    dest: "/tmp/{{ _repo.filename }}-apt-key.tmp"
+    mode: "0644"
+  register: _repo_key_download  # noqa: var-naming[no-role-prefix]
+  until: _repo_key_download is succeeded
+  retries: 3
+  delay: 2
+  when: not _repo_keyring.stat.exists
+
+- name: "Repo deb822 | Convertir la llave a keyring/dearmor ({{ _repo.filename }})"
+  ansible.builtin.command: >-
+    gpg --dearmor -o {{ _repo.keyring_path }} /tmp/{{ _repo.filename }}-apt-key.tmp
+  # Gateado por el stat: cuando corre, crea el keyring → el cambio es real.
+  when: not _repo_keyring.stat.exists
+  changed_when: true
+
+- name: "Repo deb822 | Limpiar la llave temporal ({{ _repo.filename }})"
+  ansible.builtin.file:
+    path: "/tmp/{{ _repo.filename }}-apt-key.tmp"
+    state: absent
+  when: not _repo_keyring.stat.exists
+
+- name: "Repo deb822 | Eliminar el .list legacy ({{ _repo.filename }})"
+  ansible.builtin.file:
+    path: "/etc/apt/sources.list.d/{{ _repo.filename }}.list"
+    state: absent
+
+- name: "Repo deb822 | Escribir el repositorio .sources ({{ _repo.filename }})"
+  ansible.builtin.template:
+    src: deb822.sources.j2
+    dest: "/etc/apt/sources.list.d/{{ _repo.filename }}.sources"
+    owner: root
+    group: root
+    mode: "0644"
+  register: _repo_sources  # noqa: var-naming[no-role-prefix]

--- a/roles/funcional/tasks/adhoccli.yml
+++ b/roles/funcional/tasks/adhoccli.yml
@@ -2,7 +2,6 @@
 - name: Adhoccli - Configurar repositorio Adhoc y instalar adhoccli
   tags: adhoccli
   become: true
-
   block:
     - name: Adhoccli - Asegurar prerrequisitos para repositorios APT
       ansible.builtin.apt:
@@ -11,57 +10,15 @@
           - apt-transport-https
         state: present
 
-    - name: Adhoccli - Verificar si la llave GPG ya está instalada
-      ansible.builtin.stat:
-        path: "{{ funcional_external_repos.adhoccli.keyring_path }}"
-      register: funcional_adhoccli_gpg_key
-
-    - name: Adhoccli - Descargar la llave GPG del repositorio
-      ansible.builtin.get_url:
-        url: "{{ funcional_external_repos.adhoccli.gpg_url }}"
-        dest: /tmp/adhoc-devops.asc
-        mode: "0644"
-      register: funcional_adhoccli_gpg_download
-      until: funcional_adhoccli_gpg_download is succeeded
-      retries: 3
-      delay: 2
-      when: not funcional_adhoccli_gpg_key.stat.exists
-
-    - name: Adhoccli - Convertir y guardar la llave GPG en el keyring
-      ansible.builtin.command:
-        cmd: gpg --dearmor -o {{ funcional_external_repos.adhoccli.keyring_path }} /tmp/adhoc-devops.asc
-      when: not funcional_adhoccli_gpg_key.stat.exists
-      changed_when: true
-
-    - name: Adhoccli - Remover archivo temporal de llave GPG
-      ansible.builtin.file:
-        path: /tmp/adhoc-devops.asc
-        state: absent
-      when: not funcional_adhoccli_gpg_key.stat.exists
-
-    - name: Adhoccli - Eliminar el repositorio legacy en formato .list (migración a deb822)
-      ansible.builtin.file:
-        path: /etc/apt/sources.list.d/adhoc.list
-        state: absent
-
-    - name: Adhoccli - Añadir el repositorio de Adhoc (formato deb822 .sources)
-      ansible.builtin.copy:
-        dest: /etc/apt/sources.list.d/adhoc.sources
-        owner: root
-        group: root
-        mode: "0644"
-        content: |
-          Types: deb
-          URIs: {{ funcional_external_repos.adhoccli.repo_url }}
-          Suites: stable
-          Components: main
-          Signed-By: {{ funcional_external_repos.adhoccli.keyring_path }}
-      register: funcional_adhoc_repo
+    - name: Adhoccli - Configurar keyring GPG + repositorio deb822
+      ansible.builtin.include_tasks: _setup_apt_repo.yml
+      vars:
+        _repo: "{{ funcional_external_repos.adhoccli }}"
 
     - name: Adhoccli - Instalar herramientas del repositorio Adhoc
       ansible.builtin.apt:
         update_cache: true
-        cache_valid_time: "{{ 0 if (funcional_adhoc_repo.changed | default(false)) else (funcional_apt_cache_valid_time | default(3600)) }}"
+        cache_valid_time: "{{ 0 if (_repo_sources.changed | default(false)) else (funcional_apt_cache_valid_time | default(3600)) }}"
         name:
           - adhoccli
           - streamsnap

--- a/roles/funcional/templates/deb822.sources.j2
+++ b/roles/funcional/templates/deb822.sources.j2
@@ -1,0 +1,8 @@
+Types: deb
+URIs: {{ _repo.uris }}
+Suites: {{ _repo.suites }}
+Components: {{ _repo.components }}
+{% if _repo.architectures is defined -%}
+Architectures: {{ _repo.architectures }}
+{% endif -%}
+Signed-By: {{ _repo.keyring_path }}

--- a/roles/funcional/templates/deb822.sources.j2
+++ b/roles/funcional/templates/deb822.sources.j2
@@ -3,6 +3,6 @@ URIs: {{ _repo.uris }}
 Suites: {{ _repo.suites }}
 Components: {{ _repo.components }}
 {% if _repo.architectures is defined -%}
-Architectures: {{ _repo.architectures }}
+Architectures: {{ _repo.architectures | replace(',', ' ') }}
 {% endif -%}
-Signed-By: {{ _repo.keyring_path }}
+Signed-By: {{ _repo.signed_by | default(_repo.keyring_path) }}

--- a/roles/funcional/vars/main.yml
+++ b/roles/funcional/vars/main.yml
@@ -199,8 +199,12 @@ funcional_external_repos:
     keyring_path: "/etc/apt/keyrings/kubernetes-apt-keyring.gpg"
   adhoccli:
     gpg_url: "https://apt.dev-adhoc.com/adhoc-devops.asc"
-    repo_url: "https://apt.dev-adhoc.com/"
     keyring_path: "/usr/share/keyrings/adhoc-devops.gpg"
+    # Campos estructurados deb822 (consumidos por _setup_apt_repo.yml)
+    uris: "https://apt.dev-adhoc.com/"
+    suites: "stable"
+    components: "main"
+    filename: "adhoc"
     github_url: "https://github.com/ingadhoc/adhoc-cli"
 
 # Timeouts para descargas


### PR DESCRIPTION
**Prueba de concepto** del refactor DRY que charlamos: el patrón "keyring GPG + repo deb822" está duplicado ~7 veces (docker, code, gh_cli, browsers, gcloud, kubectl, nordvpn, adhoccli), ~6-7 tareas calcadas cada uno.

## Qué trae
- **`roles/funcional/tasks/_setup_apt_repo.yml`** (helper reutilizable) + **`roles/funcional/templates/deb822.sources.j2`** (maneja `architectures` opcional con control de whitespace). Reciben una entrada de `*_external_repos` y arman keyring + `.sources`.
- **`funcional/adhoccli.yml`** migrado como PoC: **68 → 25 líneas**. El caller queda solo con: prerrequisitos → `include_tasks` del helper → install de paquetes (gateando `update_cache` con `_repo_sources.changed`).
- Vars de adhoccli normalizadas a campos deb822 estructurados (`uris`/`suites`/`components`/`filename`), como ya estaban vscode/github_cli.

## Garantías
- El `.sources` renderizado es **byte-idéntico** al anterior (verificado con render del template) → sin cambio espurio.
- El `verify` de molecule de funcional ya chequea el keyring (`/usr/share/keyrings/adhoc-devops.gpg`) y el `.sources` (`/etc/apt/sources.list.d/adhoc.sources`): ambos intactos.
- `ansible-lint` perfil **production** (playbook completo) + `yamllint` + `--syntax-check`: limpios.

## Si se valida → plan de migración del resto
1. Normalizar las vars de los repos restantes a campos deb822 estructurados.
2. Migrar docker/code/browsers/gcloud/kubectl/nordvpn/gh_cli, respetando lo que varía por repo (gateo "saltear si ya instalado" de chrome/code, grupo docker, etc. quedan en el caller).
3. Resolver el acceso cross-rol al helper: developer/sysadmin lo consumen vía `include_role: { name: funcional, tasks_from: _setup_apt_repo.yml }` (no re-ejecuta funcional).

Estimado de reducción total: ~556 → ~200 líneas en los archivos de repos.