### PR TITLE
feat(developer): preparar terreno para adhoc-way (Claude Code + Node)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Registro de cambios relevantes del proyecto. Formato basado en [Keep a Changelog
 
 ## [2026-06-27]
 
+### Feature: preparación de terreno para adhoc-way (Claude Code + Node)
+
+- Nuevo task `roles/developer/tasks/adhoc_way.yml`: instala **Node.js/npm** y la
+  **CLI de Claude Code** (vía repo APT oficial firmado, deb822) y agrega `~/.local/bin`
+  al PATH del usuario. **No** instala el paquete adhoc-way ni corre `adhoc-way init`:
+  ambos necesitan la identidad/credenciales del dev (Tuqui), que no existen al aplicar
+  Ansible → se completan en el primer `hola` / `ad install adhoc-way`
+- Política por perfil: `developer` y `sysadmin` lo aplican por defecto;
+  `freelance_developer` es **opt-in** (`-e "adhoc_way=true"`); `funcional` no lo incluye
+- Cubre el hueco previo: hasta ahora `ansible_notebooks` no preinstalaba ninguna CLI de
+  agente (tarea Odoo #67663)
+
 ### Docs: registrar decisiones de arquitectura en `specifications.md`
 
 - §3.1: documentada la decisión de **mantener el patrón de repos deb822 inline por

--- a/roles/developer/tasks/adhoc_way.yml
+++ b/roles/developer/tasks/adhoc_way.yml
@@ -1,0 +1,110 @@
+---
+# adhoc-way — preparación del terreno (NO instala adhoc-way ni corre 'init').
+#
+# Reparto de responsabilidades (decidido con DevOps, tarea Odoo #67663):
+#   - Playbook (acá, sin credenciales del dev):
+#       * Node/npm en el host (prerrequisito para el futuro 'ad install adhoc-way').
+#       * Claude Code CLI (único agente preinstalado) vía repo APT oficial.
+#       * ~/.local/bin en el PATH del usuario (npm global user-space).
+#   - Primer 'hola' / 'ad install adhoc-way' (con Tuqui authed por el dev):
+#       * 'npm i -g' del paquete adhoc-way (repo privado → necesita auth del dev).
+#       * 'adhoc-way init' (identidad ~/.adhoc/user.json).
+#
+# Gate por perfil: developer/sysadmin = true; freelance_developer = opt-in.
+- name: Adhoc Way | Preparar terreno para adhoc-way
+  tags: adhoc_way
+  when: developer_adhoc_way | default(true) | bool
+  become: true
+  block:
+    - name: Adhoc Way | Asegurar prerrequisitos (https + gnupg para el keyring)
+      ansible.builtin.apt:
+        name:
+          - ca-certificates
+          - gnupg
+          - apt-transport-https
+        state: present
+        cache_valid_time: "{{ funcional_apt_cache_valid_time | default(3600) }}"
+
+    - name: Adhoc Way | Instalar Node.js y npm (prerrequisito de adhoc-way)
+      ansible.builtin.apt:
+        name: "{{ developer_adhoc_way_node_packages }}"
+        state: present
+        cache_valid_time: "{{ funcional_apt_cache_valid_time | default(3600) }}"
+
+    # --- Claude Code CLI (repo APT oficial, binario self-contained) ---
+    - name: Adhoc Way | Crear directorio para claves GPG
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: "0755"
+
+    - name: Adhoc Way | Verificar si la clave GPG de Claude Code ya está instalada
+      ansible.builtin.stat:
+        path: "{{ developer_external_repos.claude_code.keyring_path }}"
+      register: developer_claude_code_gpg_key
+
+    - name: Adhoc Way | Descargar la clave GPG de Claude Code
+      ansible.builtin.get_url:
+        url: "{{ developer_external_repos.claude_code.gpg_url }}"
+        dest: /tmp/claude-code.asc
+        mode: "0644"
+      register: developer_claude_code_gpg_download
+      until: developer_claude_code_gpg_download is succeeded
+      retries: 3
+      delay: 2
+      when: not developer_claude_code_gpg_key.stat.exists
+
+    - name: Adhoc Way | Convertir y guardar la clave GPG en el keyring
+      ansible.builtin.command: >-
+        gpg --dearmor -o {{ developer_external_repos.claude_code.keyring_path }} /tmp/claude-code.asc
+      # Gateado por el stat de arriba: solo corre si la clave no existía y, cuando
+      # corre, crea el keyring → el cambio es real (idem code.yml/adhoccli.yml).
+      when: not developer_claude_code_gpg_key.stat.exists
+      changed_when: true
+
+    - name: Adhoc Way | Limpiar archivo temporal de la clave GPG
+      ansible.builtin.file:
+        path: /tmp/claude-code.asc
+        state: absent
+      when: not developer_claude_code_gpg_key.stat.exists
+
+    - name: Adhoc Way | Eliminar el repositorio legacy en formato .list (migración a deb822)
+      ansible.builtin.file:
+        path: "/etc/apt/sources.list.d/{{ developer_external_repos.claude_code.filename }}.list"
+        state: absent
+
+    - name: Adhoc Way | Añadir el repositorio de Claude Code (formato deb822 .sources)
+      ansible.builtin.copy:
+        dest: "/etc/apt/sources.list.d/{{ developer_external_repos.claude_code.filename }}.sources"
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          Types: deb
+          URIs: {{ developer_external_repos.claude_code.uris }}
+          Suites: {{ developer_external_repos.claude_code.suites }}
+          Components: {{ developer_external_repos.claude_code.components }}
+          Architectures: {{ developer_external_repos.claude_code.architectures | replace(',', ' ') }}
+          Signed-By: {{ developer_external_repos.claude_code.keyring_path }}
+      register: developer_claude_code_repo
+
+    - name: Adhoc Way | Instalar el paquete 'claude-code'
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: "{{ 0 if (developer_claude_code_repo.changed | default(false)) else (funcional_apt_cache_valid_time | default(3600)) }}"
+        name: claude-code
+        state: present
+
+# --- PATH del usuario (npm global en user-space → ~/.local/bin) ---
+- name: Adhoc Way | Asegurar ~/.local/bin en el PATH del usuario
+  tags: adhoc_way
+  when: developer_adhoc_way | default(true) | bool
+  become: true
+  become_user: "{{ remote_regular_user }}"
+  ansible.builtin.blockinfile:
+    path: "/home/{{ remote_regular_user }}/.bashrc"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - adhoc-way PATH"
+    block: |
+      # adhoc-way / npm global (user-space)
+      export PATH="$HOME/.local/bin:$PATH"
+    create: false

--- a/roles/developer/tasks/main.yml
+++ b/roles/developer/tasks/main.yml
@@ -22,3 +22,5 @@
       ansible.builtin.import_tasks: ssh.yml
     - name: Developer - GH
       ansible.builtin.import_tasks: gh_cli.yml
+    - name: Developer - Adhoc Way (terreno)
+      ansible.builtin.import_tasks: adhoc_way.yml

--- a/roles/developer/vars/main.yml
+++ b/roles/developer/vars/main.yml
@@ -173,3 +173,26 @@ developer_external_repos:
     suites: "stable"
     components: "main"
     architectures: "amd64"
+  claude_code:
+    # Repo APT oficial de Claude Code (binario self-contained, no requiere Node).
+    # Vía apt no se autoactualiza: las upgrades vienen por 'apt upgrade'.
+    # Verificar contra https://code.claude.com/docs/en/install.md si algo falla.
+    gpg_url: "https://downloads.claude.ai/keys/claude-code.asc"
+    keyring_path: "/etc/apt/keyrings/claude-code.gpg"
+    uris: "https://downloads.claude.ai/claude-code/apt/stable"
+    suites: "stable"
+    components: "main"
+    architectures: "amd64,arm64"
+    filename: "claude-code"
+
+# --- adhoc-way: preparación del terreno ---
+# El rol NO instala adhoc-way ni corre 'adhoc-way init': ambos pasos necesitan la
+# identidad/credenciales del dev (Tuqui), que no existen al aplicar Ansible. Se
+# completan en el primer 'hola' / 'ad install adhoc-way' cuando el dev toma posesión del
+# equipo. Acá solo dejamos: Node/npm + Claude Code + ~/.local/bin en PATH.
+developer_adhoc_way_node_packages:
+  - nodejs
+  - npm
+
+# Gate del task. developer/sysadmin = true por política; freelance = opt-in.
+developer_adhoc_way: true

--- a/roles/freelance_developer/tasks/main.yml
+++ b/roles/freelance_developer/tasks/main.yml
@@ -98,3 +98,11 @@
         name: developer
         tasks_from: gh_cli.yml
       tags: [developer, gh, github]
+
+    # Opt-in para freelance: solo con -e "adhoc_way=true".
+    - name: Developer | Adhoc Way (terreno, opt-in)
+      ansible.builtin.include_role:
+        name: developer
+        tasks_from: adhoc_way.yml
+      when: adhoc_way | default(false) | bool
+      tags: [developer, adhoc_way]

--- a/roles/sysadmin/tasks/main.yml
+++ b/roles/sysadmin/tasks/main.yml
@@ -18,15 +18,6 @@
       ansible.builtin.import_tasks: theme_desktop.yml
     - name: SysAdmin - Fixes
       ansible.builtin.import_tasks: fixes.yml
-
-    # adhoc-way (terreno): reutiliza el task del rol developer. Necesita sus vars
-    # (developer_external_repos.claude_code, developer_adhoc_way_node_packages).
-    - name: SysAdmin - Cargar vars del rol developer para adhoc-way
-      ansible.builtin.include_vars: "{{ role_path | dirname }}/developer/vars/main.yml"
-      tags: [adhoc_way]
-      no_log: true
-    - name: SysAdmin - Adhoc Way (terreno)
-      ansible.builtin.include_role:
-        name: developer
-        tasks_from: adhoc_way.yml
-      tags: [adhoc_way]
+    # adhoc-way (terreno) NO se incluye acá: el perfil sysadmin ya ejecuta el rol
+    # 'developer' por dependencia (meta/main.yml), y developer/tasks/main.yml ya
+    # importa adhoc_way.yml. Agregarlo de nuevo duplicaría el trabajo (APT incluido).

--- a/roles/sysadmin/tasks/main.yml
+++ b/roles/sysadmin/tasks/main.yml
@@ -18,3 +18,15 @@
       ansible.builtin.import_tasks: theme_desktop.yml
     - name: SysAdmin - Fixes
       ansible.builtin.import_tasks: fixes.yml
+
+    # adhoc-way (terreno): reutiliza el task del rol developer. Necesita sus vars
+    # (developer_external_repos.claude_code, developer_adhoc_way_node_packages).
+    - name: SysAdmin - Cargar vars del rol developer para adhoc-way
+      ansible.builtin.include_vars: "{{ role_path | dirname }}/developer/vars/main.yml"
+      tags: [adhoc_way]
+      no_log: true
+    - name: SysAdmin - Adhoc Way (terreno)
+      ansible.builtin.include_role:
+        name: developer
+        tasks_from: adhoc_way.yml
+      tags: [adhoc_way]


### PR DESCRIPTION
## Qué

Prepara el terreno para **adhoc-way** en los notebooks, sin instalarlo todavía. Tarea Odoo #67663.

Nuevo task `roles/developer/tasks/adhoc_way.yml` que:

- instala **Node.js/npm** (prerrequisito del futuro `ad install adhoc-way`),
- instala la **CLI de Claude Code** vía su **repo APT oficial firmado** (deb822, paquete `claude-code`, binario self-contained sin Node en runtime),
- agrega `~/.local/bin` al **PATH** del usuario.

## Qué NO hace (a propósito)

No instala el paquete adhoc-way ni corre `adhoc-way init`. Ambos necesitan la identidad/credenciales del dev (Tuqui), que no existen al aplicar Ansible → se completan en el primer `hola` / `ad install adhoc-way` cuando el dev toma posesión del equipo. El bootstrapper `ad install adhoc-way` se implementa aparte en el repo de adhocCli.

## Política por perfil

| Perfil | adhoc-way |
|---|---|
| `developer` | sí (default) |
| `sysadmin` | sí |
| `freelance_developer` | opt-in (`-e "adhoc_way=true"`) |
| `funcional` | no |

## Idempotencia

Sigue el patrón del repo: keyring stat-gated + `changed_when` veraz en el `dearmor`, `.sources` deb822 estable, `apt` con `cache_valid_time` gateado por `repo.changed`.

## Validación

- `yamllint` y `ansible-lint` (perfil `production`) limpios en los archivos nuevos.
- `ansible-playbook --syntax-check` OK en developer / sysadmin / freelance_developer.
- URL/suite del repo APT y nombre de paquete verificados contra la doc oficial de Claude Code.
- Idempotencia e instalación real de `claude-code` quedan cubiertas por molecule en CI (no corre confiable en sandbox local).