### PR TITLE
chore: quitar condicional os_family en task kvm

### DIFF
--- a/roles/sysadmin/tasks/kvm.yml
+++ b/roles/sysadmin/tasks/kvm.yml
@@ -3,7 +3,6 @@
   tags: kvm
   become: true
   when:
-    - ansible_facts['os_family'] == 'Debian'
     - not (sysadmin_skip_kvm | default(false))
   block:
     - name: KVM | Verificar soporte de virtualización en CPU


### PR DESCRIPTION
## Qué cambia

Quita el condicional `ansible_facts['os_family'] == 'Debian'` del `when` de la task KVM/QEMU en el rol `sysadmin`.

## Por qué

El proyecto está diseñado **solo para Debian 13 (Trixie)**: el README lo declara explícitamente y el CI corre únicamente sobre Debian 13. Ese `when` era el único condicional defensivo de OS en todo el rol y contradecía el contrato del proyecto — código muerto que nunca evalúa a falso en los entornos soportados.

Se mantiene intacto el toggle `sysadmin_skip_kvm` (no es un condicional de OS, sino el control que usa molecule/CI para saltear la instalación de KVM dentro de containers).

## Test plan

- [ ] `ansible-lint roles/sysadmin/tasks/kvm.yml` pasa (profile `production`).
- [ ] `ansible-playbook local.yml -e "profile_override=sysadmin" --tags "kvm" -K` instala KVM en un host Debian 13.
- [ ] Molecule sigue pudiendo saltear KVM vía `sysadmin_skip_kvm=true`.
