### PR TITLE
chore: cachear pip y collections en los jobs de test de Molecule CI

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -72,9 +72,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.ansible/collections
-          key: ansible-collections-${{ hashFiles('collections/requirements.yml') }}
+          key: ansible-collections-${{ runner.os }}-${{ hashFiles('collections/requirements.yml') }}
           restore-keys: |
-            ansible-collections-
+            ansible-collections-${{ runner.os }}-
 
       - name: Install dependencies
         run: |
@@ -135,11 +135,21 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
+
+      - name: Cache Ansible collections
+        uses: actions/cache@v4
+        with:
+          path: ~/.ansible/collections
+          key: ansible-collections-${{ runner.os }}-${{ hashFiles('collections/requirements.yml') }}
+          restore-keys: |
+            ansible-collections-${{ runner.os }}-
 
       - name: Install Ansible collections
         run: |
@@ -190,11 +200,21 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
+
+      - name: Cache Ansible collections
+        uses: actions/cache@v4
+        with:
+          path: ~/.ansible/collections
+          key: ansible-collections-${{ runner.os }}-${{ hashFiles('collections/requirements.yml') }}
+          restore-keys: |
+            ansible-collections-${{ runner.os }}-
 
       - name: Install Ansible collections
         run: |
@@ -245,11 +265,21 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
+
+      - name: Cache Ansible collections
+        uses: actions/cache@v4
+        with:
+          path: ~/.ansible/collections
+          key: ansible-collections-${{ runner.os }}-${{ hashFiles('collections/requirements.yml') }}
+          restore-keys: |
+            ansible-collections-${{ runner.os }}-
 
       - name: Install Ansible collections
         run: |


### PR DESCRIPTION
## Qué

Agrega cache de dependencias a los 3 jobs de test de Molecule CI (`test-funcional`, `test-developer`, `test-sysadmin`):

- **`cache: pip`** vía `actions/setup-python@v5`, keyed por `requirements-dev.txt`.
- **Cache de `~/.ansible/collections`** keyed por `collections/requirements.yml`, mismo patrón que ya usaba el job `lint`.

## Por qué

Los 3 jobs reinstalaban el stack de molecule/ansible y descargaban las collections de galaxy en cada run, sin cache. Eso es overhead de setup puro, repetido en cada job (~7–14 min por job hoy).

## Alcance

No se toca ninguna task del `converge` ni del `verify` — la cobertura de tests queda idéntica. El recorte es solo el overhead de setup. El beneficio aparece a partir del segundo run (el primero crea la cache).