### PR TITLE
fix: migrar facts auto-inyectados a ansible_facts[] (INJECT_FACTS_AS_VARS)

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,9 @@
 [defaults]
 deprecation_warnings = True
+# Los facts NO se auto-inyectan como variables top-level con prefijo ansible_;
+# se accede solo vía ansible_facts['nombre']. Anticipa el cambio de default de
+# ansible-core (INJECT_FACTS_AS_VARS se elimina en 2.24) y silencia el warning.
+inject_facts_as_vars = False
 inventory = hosts
 roles_path = ./roles/
 collections_path = ~/.ansible/collections

--- a/roles/deploy/vars/main.yml
+++ b/roles/deploy/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 # Usuario genérico para ejecutar algunas tareas
-remote_regular_user: "{{ ansible_env.SUDO_USER | default(ansible_user) }}"  # noqa: var-naming[no-role-prefix]
+remote_regular_user: "{{ ansible_facts['env'].SUDO_USER | default(ansible_user) }}"  # noqa: var-naming[no-role-prefix]
 
 # --- Configuración para Pulumi ---
 # Por defecto instala la última release estable. Para pinnear:

--- a/roles/developer/molecule/default/converge.yml
+++ b/roles/developer/molecule/default/converge.yml
@@ -4,8 +4,6 @@
   become: true
 
   vars:
-    ansible_env:
-      SUDO_USER: testuser
     skip_gnome_tasks: true
     developer_manage_vscode_extensions: false
     developer_manage_vscode_defaults: false
@@ -14,6 +12,10 @@
     developer_skip_remote_dev: true
 
   pre_tasks:
+    - name: Converge | Simulate sudo invocation (SUDO_USER) for the role  # noqa: var-naming[no-role-prefix]
+      ansible.builtin.set_fact:
+        ansible_facts: "{{ ansible_facts | combine({'env': {'SUDO_USER': 'testuser'}}, recursive=True) }}"
+
     - name: Update apt cache
       ansible.builtin.apt:
         update_cache: true

--- a/roles/developer/molecule/default/molecule.yml
+++ b/roles/developer/molecule/default/molecule.yml
@@ -29,6 +29,9 @@ provisioner:
       stdout_callback: default
       result_format: yaml
       roles_path: ../../../../roles
+      # Replica el ansible.cfg del repo: testea el escenario post-deprecación
+      # (facts solo vía ansible_facts['...'], sin auto-inyección top-level).
+      inject_facts_as_vars: false
   inventory:
     host_vars:
       debian13-developer:

--- a/roles/developer/molecule/default/prepare.yml
+++ b/roles/developer/molecule/default/prepare.yml
@@ -18,11 +18,6 @@
         create_home: true
         shell: /bin/bash
 
-    - name: Prepare | Set SUDO_USER environment for testing  # noqa: var-naming[no-role-prefix]
-      ansible.builtin.set_fact:
-        ansible_env:
-          SUDO_USER: testuser
-
     - name: Prepare | Ensure /tmp has correct permissions
       ansible.builtin.file:
         path: /tmp

--- a/roles/developer/molecule/default/verify.yml
+++ b/roles/developer/molecule/default/verify.yml
@@ -8,7 +8,7 @@
     - ../../vars/main.yml
 
   vars:
-    developer_remote_user: "{{ ansible_env.SUDO_USER | default('testuser') }}"
+    developer_remote_user: "{{ ansible_facts['env'].SUDO_USER | default('testuser') }}"
     docker_group_user: "{{ developer_remote_user }}"
     required_package_sets:
       - "{{ developer_packages_base }}"

--- a/roles/developer/tasks/docker.yml
+++ b/roles/developer/tasks/docker.yml
@@ -54,10 +54,10 @@
         mode: "0644"
         content: |
           Types: deb
-          URIs: {{ developer_external_repos.docker.repo_url }}/{{ ansible_distribution | lower }}
-          Suites: {{ ansible_distribution_release }}
+          URIs: {{ developer_external_repos.docker.repo_url }}/{{ ansible_facts['distribution'] | lower }}
+          Suites: {{ ansible_facts['distribution_release'] }}
           Components: stable
-          Architectures: {{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}
+          Architectures: {{ 'amd64' if ansible_facts['architecture'] == 'x86_64' else 'arm64' }}
           Signed-By: {{ developer_external_repos.docker.keyring_path }}
       register: developer_docker_repo
 

--- a/roles/developer/vars/main.yml
+++ b/roles/developer/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 # Usuario genérico para ejecutar algunas tareas
-remote_regular_user: "{{ ansible_env.SUDO_USER | default(ansible_user) }}"  # noqa: var-naming[no-role-prefix]
-remote_regular_user_uid: "{{ ansible_env.SUDO_UID | default(ansible_user_uid) }}"  # noqa: var-naming[no-role-prefix]
+remote_regular_user: "{{ ansible_facts['env'].SUDO_USER | default(ansible_user) }}"  # noqa: var-naming[no-role-prefix]
+remote_regular_user_uid: "{{ ansible_facts['env'].SUDO_UID | default(ansible_facts['user_uid']) }}"  # noqa: var-naming[no-role-prefix]
 
 # Lista de paquetes base para el perfil de DEV
 developer_packages_base:
@@ -137,7 +137,7 @@ developer_odoo_ctx_repo: "https://github.com/ingadhoc/docker-compose-context.git
 developer_odoo_main_repo: "https://github.com/ingadhoc/docker-compose-odoo.git"
 
 developer_ssh_config:
-  key_path: "/home/{{ remote_regular_user }}/.ssh/id_rsa_{{ remote_regular_user }}@{{ ansible_hostname }}"
+  key_path: "/home/{{ remote_regular_user }}/.ssh/id_rsa_{{ remote_regular_user }}@{{ ansible_facts['hostname'] }}"
   key_type: "rsa"
   key_size: 4096
   config_template_src: "sshconfig.j2"

--- a/roles/freelance_developer/molecule/default/converge.yml
+++ b/roles/freelance_developer/molecule/default/converge.yml
@@ -4,8 +4,6 @@
   become: true
 
   vars:
-    ansible_env:
-      SUDO_USER: testuser
     skip_gnome_tasks: true
     developer_manage_vscode_extensions: false
     developer_manage_vscode_defaults: false
@@ -14,6 +12,10 @@
     developer_skip_remote_dev: true
 
   pre_tasks:
+    - name: Converge | Simulate sudo invocation (SUDO_USER) for the role  # noqa: var-naming[no-role-prefix]
+      ansible.builtin.set_fact:
+        ansible_facts: "{{ ansible_facts | combine({'env': {'SUDO_USER': 'testuser'}}, recursive=True) }}"
+
     - name: Update apt cache
       ansible.builtin.apt:
         update_cache: true

--- a/roles/freelance_developer/molecule/default/molecule.yml
+++ b/roles/freelance_developer/molecule/default/molecule.yml
@@ -29,6 +29,9 @@ provisioner:
       stdout_callback: default
       result_format: yaml
       roles_path: ../../../../roles
+      # Replica el ansible.cfg del repo: testea el escenario post-deprecación
+      # (facts solo vía ansible_facts['...'], sin auto-inyección top-level).
+      inject_facts_as_vars: false
   inventory:
     host_vars:
       debian13-freelance-developer:

--- a/roles/freelance_developer/molecule/default/prepare.yml
+++ b/roles/freelance_developer/molecule/default/prepare.yml
@@ -18,11 +18,6 @@
         create_home: true
         shell: /bin/bash
 
-    - name: Prepare | Set SUDO_USER environment for testing  # noqa: var-naming[no-role-prefix]
-      ansible.builtin.set_fact:
-        ansible_env:
-          SUDO_USER: testuser
-
     - name: Prepare | Ensure /tmp has correct permissions
       ansible.builtin.file:
         path: /tmp

--- a/roles/funcional/molecule/default/converge.yml
+++ b/roles/funcional/molecule/default/converge.yml
@@ -4,13 +4,15 @@
   become: true
 
   vars:
-    # Simular que estamos corriendo con sudo
-    ansible_env:
-      SUDO_USER: testuser
     # Deshabilitar tareas de GUI que no funcionan en Docker
     skip_gnome_tasks: true
 
   pre_tasks:
+    # Simular que estamos corriendo con sudo
+    - name: Converge | Simulate sudo invocation (SUDO_USER) for the role  # noqa: var-naming[no-role-prefix]
+      ansible.builtin.set_fact:
+        ansible_facts: "{{ ansible_facts | combine({'env': {'SUDO_USER': 'testuser'}}, recursive=True) }}"
+
     - name: Update apt cache
       ansible.builtin.apt:
         update_cache: true

--- a/roles/funcional/molecule/default/molecule.yml
+++ b/roles/funcional/molecule/default/molecule.yml
@@ -29,6 +29,9 @@ provisioner:
       stdout_callback: default
       result_format: yaml
       roles_path: ../../../../roles
+      # Replica el ansible.cfg del repo: testea el escenario post-deprecación
+      # (facts solo vía ansible_facts['...'], sin auto-inyección top-level).
+      inject_facts_as_vars: false
   inventory:
     host_vars:
       debian13-funcional:

--- a/roles/funcional/molecule/default/prepare.yml
+++ b/roles/funcional/molecule/default/prepare.yml
@@ -18,11 +18,6 @@
         create_home: true
         shell: /bin/bash
 
-    - name: Prepare | Set SUDO_USER environment for testing  # noqa: var-naming[no-role-prefix]
-      ansible.builtin.set_fact:
-        ansible_env:
-          SUDO_USER: testuser
-
     - name: Prepare | Ensure /tmp has correct permissions
       ansible.builtin.file:
         path: /tmp

--- a/roles/funcional/tasks/local_dns.yml
+++ b/roles/funcional/tasks/local_dns.yml
@@ -15,7 +15,7 @@
         update_cache: true
       when:
         - ansible_facts['distribution'] == 'Debian'
-        - not (ansible_virtualization_type == 'docker' or skip_dns_config | default(false))
+        - not (ansible_facts['virtualization_type'] == 'docker' or skip_dns_config | default(false))
 
     # 2. Habilita el servicio (Garantiza que /run/systemd/resolve/ existe)
     - name: DNS | Asegurar que systemd-resolved esté habilitado y corriendo
@@ -23,7 +23,7 @@
         name: systemd-resolved.service
         enabled: true
         state: started
-      when: not (ansible_virtualization_type == 'docker' or skip_dns_config | default(false))
+      when: not (ansible_facts['virtualization_type'] == 'docker' or skip_dns_config | default(false))
 
     # 3. Configura el servicio
     - name: DNS | Configurar servidores DNS en resolved.conf
@@ -39,7 +39,7 @@
         - { option: "FallbackDNS", value: "" }
         - { option: "DNSOverTLS", value: "yes" }
       notify: Restart systemd-resolved # Asumo que tienes este handler definido
-      when: not (ansible_virtualization_type == 'docker' or skip_dns_config | default(false))
+      when: not (ansible_facts['virtualization_type'] == 'docker' or skip_dns_config | default(false))
 
     # 4. Crea el enlace simbólico
     - name: DNS | Asegurar que /etc/resolv.conf sea un enlace a systemd-resolved
@@ -49,4 +49,4 @@
         state: link
         force: true
       notify: Restart systemd-resolved
-      when: not (ansible_virtualization_type == 'docker' or skip_dns_config | default(false))
+      when: not (ansible_facts['virtualization_type'] == 'docker' or skip_dns_config | default(false))

--- a/roles/funcional/vars/main.yml
+++ b/roles/funcional/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 # Usuario genérico para ejecutar algunas tareas (con valor por defecto)
-remote_regular_user: "{{ ansible_env.SUDO_USER | default(ansible_user) }}"  # noqa: var-naming[no-role-prefix]
+remote_regular_user: "{{ ansible_facts['env'].SUDO_USER | default(ansible_user) }}"  # noqa: var-naming[no-role-prefix]
 
 # INTERRUPTOR PRINCIPAL PARA EL ESTILO DE ESCRITORIOS VIRTUALES
 # Opciones válidas: 'dynamic' o 'fixed'

--- a/roles/sysadmin/molecule/default/converge.yml
+++ b/roles/sysadmin/molecule/default/converge.yml
@@ -4,8 +4,6 @@
   become: true
 
   vars:
-    ansible_env:
-      SUDO_USER: testuser
     skip_gnome_tasks: true
     developer_manage_vscode_extensions: false
     developer_manage_vscode_defaults: false
@@ -19,6 +17,10 @@
     sysadmin_skip_nordvpn_service: true
 
   pre_tasks:
+    - name: Converge | Simulate sudo invocation (SUDO_USER) for the role  # noqa: var-naming[no-role-prefix]
+      ansible.builtin.set_fact:
+        ansible_facts: "{{ ansible_facts | combine({'env': {'SUDO_USER': 'testuser'}}, recursive=True) }}"
+
     - name: Update apt cache
       ansible.builtin.apt:
         update_cache: true

--- a/roles/sysadmin/molecule/default/molecule.yml
+++ b/roles/sysadmin/molecule/default/molecule.yml
@@ -29,6 +29,9 @@ provisioner:
       stdout_callback: default
       result_format: yaml
       roles_path: ../../../../roles
+      # Replica el ansible.cfg del repo: testea el escenario post-deprecación
+      # (facts solo vía ansible_facts['...'], sin auto-inyección top-level).
+      inject_facts_as_vars: false
   inventory:
     host_vars:
       debian13-sysadmin:

--- a/roles/sysadmin/molecule/default/prepare.yml
+++ b/roles/sysadmin/molecule/default/prepare.yml
@@ -18,11 +18,6 @@
         shell: /bin/bash
         create_home: true
 
-    - name: Prepare | Set SUDO_USER environment for testing  # noqa: var-naming[no-role-prefix]
-      ansible.builtin.set_fact:
-        ansible_env:
-          SUDO_USER: testuser
-
     - name: Prepare | Ensure /tmp has correct permissions
       ansible.builtin.file:
         path: /tmp

--- a/roles/sysadmin/molecule/default/verify.yml
+++ b/roles/sysadmin/molecule/default/verify.yml
@@ -8,7 +8,7 @@
     - ../../vars/main.yml
 
   vars:
-    sysadmin_remote_user: "{{ ansible_env.SUDO_USER | default('testuser') }}"
+    sysadmin_remote_user: "{{ ansible_facts['env'].SUDO_USER | default('testuser') }}"
 
     # Paquetes específicos de sysadmin que deben estar instalados
     required_sysadmin_packages:

--- a/roles/sysadmin/vars/main.yml
+++ b/roles/sysadmin/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 # Usuario genérico para ejecutar algunas tareas
-remote_regular_user: "{{ ansible_env.SUDO_USER | default(ansible_user) }}"  # noqa: var-naming[no-role-prefix]
-remote_regular_user_uid: "{{ ansible_env.SUDO_UID | default(ansible_user_uid) }}"  # noqa: var-naming[no-role-prefix]
+remote_regular_user: "{{ ansible_facts['env'].SUDO_USER | default(ansible_user) }}"  # noqa: var-naming[no-role-prefix]
+remote_regular_user_uid: "{{ ansible_facts['env'].SUDO_UID | default(ansible_facts['user_uid']) }}"  # noqa: var-naming[no-role-prefix]
 
 # --- Configuración para Pulumi ---
 # Pulumi se instala como binario en /usr/local/bin/pulumi.


### PR DESCRIPTION
## Qué

`ansible-core` deprecó el default `INJECT_FACTS_AS_VARS=True` y lo elimina en **2.24**: los facts dejan de auto-inyectarse como variables top-level con prefijo `ansible_` (de ahí el `[DEPRECATION WARNING]` al aplicar los roles). Se migran todos los usos a la forma canónica `ansible_facts['...']`.

## Cambios

**Código de roles:**
- `vars/main.yml` (deploy, developer, funcional, sysadmin): `ansible_env` → `ansible_facts['env']`, `ansible_user_uid` → `ansible_facts['user_uid']`, `ansible_hostname` → `ansible_facts['hostname']`.
  - `ansible_user` queda **intacto**: es connection var, no fact (no se migra).
- `developer/tasks/docker.yml`: `ansible_distribution` / `ansible_distribution_release` / `ansible_architecture`.
- `funcional/tasks/local_dns.yml`: `ansible_virtualization_type` (×4).

**Tests molecule (migrados en coordinación):**
- `converge.yml` inyecta el sub-fact con `set_fact` + `combine(recursive=True)` en un `pre_task` (el play var `ansible_env` ya no alimenta `ansible_facts['env']`).
- `verify.yml` lee `ansible_facts['env'].SUDO_USER`.
- Se elimina de `prepare.yml` el `set_fact` de `SUDO_USER`: era scaffolding inerte (sin fact caching no propagaba a `converge`, que ya re-inyecta).

**Validación del escenario futuro:**
- `inject_facts_as_vars = False` en `ansible.cfg` y en `config_options.defaults` de cada `molecule.yml`, para que el molecule test corra el escenario post-deprecación (no solo el default permisivo que acepta ambas formas).

## Test plan

- [x] `ansible-playbook --syntax-check` de `local.yml` y `assign_laptop.yml`.
- [x] `yamllint` + `ansible-lint` (perfil `production`) limpios.
- [x] Verificado en `ansible-core 2.19.11` con `inject_facts_as_vars=false` que la técnica `set_fact` + `combine(recursive)` deja `ansible_facts['env'].SUDO_USER` legible por el role y preserva el resto de facts.
- [ ] **Molecule CI** (`funcional` / `developer` / `sysadmin` en debian13) corriendo ya con el flag en `false` — la prueba de fuego del escenario real.