### PR TITLE
fix(wine-microsip): soportar Ubuntu además de Debian al armar el repo WineHQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ Registro de cambios relevantes del proyecto. Formato basado en [Keep a Changelog
 
 ---
 
+## [2026-06-30]
+
+### Asistencia: `wine-microsip` ahora soporta Debian y Ubuntu
+
+- `funcional/wine-microsip.yml`: la descarga del repo WineHQ estaba clavada a
+  `debian/dists/trixie/winehq-trixie.sources`, así que al aplicar `asistencia=true`
+  sobre una notebook Ubuntu le metía un repo de Debian y rompía APT. Ahora la URL y
+  el `dest` se arman con los facts de la distro (`ansible_distribution | lower` →
+  `debian`/`ubuntu`, `ansible_distribution_release` → `trixie`/`noble`/`jammy`/…),
+  de modo que el bloque `asistencia` corre tal cual en ambas distros
+- Motivación: instalar Wine + MicroSIP en una notebook Ubuntu ya entregada, corriendo
+  `ansible-playbook local.yml -e "asistencia=true" --tags asistencia -K` localmente
+  (el `--tags asistencia` acota la corrida solo al bloque de MicroSIP, sin aplicar el
+  resto del rol `funcional`, que sigue probado solo sobre Debian Trixie)
+
 ## [2026-06-27]
 
 ### Feature: preparación de terreno para adhoc-way (Claude Code + Node)

--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ ansible-playbook local.yml -e "profile_override=sysadmin" --tags "kvm" -K --verb
 > # Developer + asistencia
 > ansible-playbook local.yml -e "profile_override=developer" -e "asistencia=true" -K --verbose
 > ```
+>
+> El bloque de Wine + MicroSIP soporta **Debian y Ubuntu** (arma el repo de WineHQ
+> según la distro). Para instalar **solo** MicroSIP sobre una notebook ya entregada,
+> sin reaplicar el resto del perfil, acotá con el tag `asistencia`:
+>
+> ```bash
+> ansible-playbook local.yml -e "asistencia=true" --tags asistencia -K --verbose
+> ```
 
 ---
 

--- a/roles/funcional/tasks/wine-microsip.yml
+++ b/roles/funcional/tasks/wine-microsip.yml
@@ -29,13 +29,18 @@
         mode: "0644"
 
     # ===== 4. Descargar archivo .sources de WineHQ (Debian/Ubuntu) =====
-    # La URL se arma con los facts de la distro para soportar Debian y Ubuntu:
-    #   ansible_distribution        -> debian | ubuntu   (lower para la ruta)
-    #   ansible_distribution_release -> trixie | noble | jammy | ...
+    # La URL se arma con los facts de la distro para soportar Debian y Ubuntu.
+    # Se accede vía ansible_facts['...'] porque el repo corre con
+    # inject_facts_as_vars=False (no existe la var top-level ansible_distribution):
+    #   ansible_facts['distribution']         -> Debian | Ubuntu (lower para la ruta)
+    #   ansible_facts['distribution_release'] -> trixie | noble | jammy | ...
     - name: Wine & MicroSIP | Download WineHQ sources file (Debian/Ubuntu)
+      vars:
+        funcional_winehq_distro: "{{ ansible_facts['distribution'] | lower }}"
+        funcional_winehq_release: "{{ ansible_facts['distribution_release'] }}"
       ansible.builtin.get_url:
-        url: "https://dl.winehq.org/wine-builds/{{ ansible_distribution | lower }}/dists/{{ ansible_distribution_release }}/winehq-{{ ansible_distribution_release }}.sources"
-        dest: "/etc/apt/sources.list.d/winehq-{{ ansible_distribution_release }}.sources"
+        url: "https://dl.winehq.org/wine-builds/{{ funcional_winehq_distro }}/dists/{{ funcional_winehq_release }}/winehq-{{ funcional_winehq_release }}.sources"
+        dest: "/etc/apt/sources.list.d/winehq-{{ funcional_winehq_release }}.sources"
         mode: "0644"
 
     # ===== 5. Actualizar cache APT con repo WineHQ =====

--- a/roles/funcional/tasks/wine-microsip.yml
+++ b/roles/funcional/tasks/wine-microsip.yml
@@ -1,5 +1,5 @@
 ---
-# Instalación de Wine + MicroSIP para asistencia telefónica (Debian Trixie)
+# Instalación de Wine + MicroSIP para asistencia telefónica (Debian/Ubuntu)
 - name: Wine & MicroSIP | Setup Wine and MicroSIP for assistance
   tags: asistencia
   block:
@@ -28,11 +28,14 @@
         dest: /etc/apt/keyrings/winehq-archive.key
         mode: "0644"
 
-    # ===== 4. Descargar archivo .sources de WineHQ para Trixie =====
-    - name: Wine & MicroSIP | Download WineHQ Trixie sources file
+    # ===== 4. Descargar archivo .sources de WineHQ (Debian/Ubuntu) =====
+    # La URL se arma con los facts de la distro para soportar Debian y Ubuntu:
+    #   ansible_distribution        -> debian | ubuntu   (lower para la ruta)
+    #   ansible_distribution_release -> trixie | noble | jammy | ...
+    - name: Wine & MicroSIP | Download WineHQ sources file (Debian/Ubuntu)
       ansible.builtin.get_url:
-        url: https://dl.winehq.org/wine-builds/debian/dists/trixie/winehq-trixie.sources
-        dest: /etc/apt/sources.list.d/winehq-trixie.sources
+        url: "https://dl.winehq.org/wine-builds/{{ ansible_distribution | lower }}/dists/{{ ansible_distribution_release }}/winehq-{{ ansible_distribution_release }}.sources"
+        dest: "/etc/apt/sources.list.d/winehq-{{ ansible_distribution_release }}.sources"
         mode: "0644"
 
     # ===== 5. Actualizar cache APT con repo WineHQ =====


### PR DESCRIPTION
## Resumen

La task de asistencia (`roles/funcional/tasks/wine-microsip.yml`) tenía la descarga del repo WineHQ clavada a `debian/dists/trixie/winehq-trixie.sources`. Al aplicar `asistencia=true` sobre una notebook **Ubuntu**, esto le agregaba un repo de Debian y rompía APT.

Ahora la URL y el `dest` se arman con los facts de la distro, así el bloque `asistencia` corre tal cual en Debian y Ubuntu:

- `ansible_distribution | lower` → `debian` / `ubuntu`
- `ansible_distribution_release` → `trixie` / `noble` / `jammy` / …

## Motivación

Instalar Wine + MicroSIP en una notebook Ubuntu ya entregada, corriendo localmente:

```bash
ansible-playbook local.yml -e "asistencia=true" --tags asistencia -K --verbose
```

El `--tags asistencia` acota la corrida solo al bloque de MicroSIP, sin reaplicar el resto del rol `funcional` (que sigue probado solo sobre Debian Trixie).

## Cambios

- `roles/funcional/tasks/wine-microsip.yml`: repo WineHQ por facts de distro
- `CHANGELOG.md`: entrada `[2026-06-30]`
- `README.md`: nota de asistencia actualizada (Debian/Ubuntu + uso del tag `asistencia`)

## Test plan

- `yamllint` limpio sobre la task
- `ansible-lint` perfil `production` limpio sobre la task
- Molecule en CI valida converge + idempotencia sobre Debian Trixie (no se altera el comportamiento existente: para `ansible_distribution=Debian`, `ansible_distribution_release=trixie` la URL resultante es idéntica a la anterior)