### PR TITLE
chore: pinear versiones de collections en requirements.yml

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,5 +1,8 @@
 ---
 collections:
   - name: community.general
+    version: "13.2.0"
   - name: ansible.posix
+    version: "2.2.2"
   - name: community.crypto
+    version: "3.3.0"


### PR DESCRIPTION
## Qué

Pinea versión exacta de las 3 collections en `collections/requirements.yml`:

- `community.general` → `13.2.0`
- `ansible.posix` → `2.2.2`
- `community.crypto` → `3.3.0`

## Por qué

Follow-up de #38 (cache de `~/.ansible/collections` keyed por el hash de este archivo). Copilot había observado que, sin pin, la key del cache queda congelada al primer resultado que resolvió `ansible-galaxy install` — de forma accidental, no explícita.

Pinear versión exacta hace dos cosas a la vez:

- **Eficiencia**: la key del cache se mantiene estable hasta que alguien decida bumpear, sin necesidad de `--upgrade` en cada run.
- **Seguridad/reproducibilidad**: la versión corriendo queda explícita y reviewable en el diff, y el bump es un acto consciente (se puede chequear changelog/CVEs antes de subir versión), en vez de depender de qué haya cacheado Galaxy en el primer run.

Decisión completa y alternativas descartadas (`--upgrade` sin pin, status quo) en ingadhoc/devops-it-project#10.

## Test plan

- [x] `ansible-galaxy collection install -r collections/requirements.yml` instala las 3 versiones pineadas sin error.
- [x] `pre-commit run --files collections/requirements.yml` pasa (yamllint, ansible-lint, etc).

Closes ingadhoc/devops-it-project#10