### PR TITLE
docs(developer): ad install adhoc-way ya existe, no es futuro

### DIFF
--- a/roles/developer/tasks/adhoc_way.yml
+++ b/roles/developer/tasks/adhoc_way.yml
@@ -3,7 +3,7 @@
 #
 # Reparto de responsabilidades (decidido con DevOps, tarea Odoo #67663):
 #   - Playbook (acá, sin credenciales del dev):
-#       * Node/npm en el host (prerrequisito de 'ad install adhoc-way', adhocCli >= v0.1.4).
+#       * Node/npm en el host (prerrequisito de 'ad install adhoc-way', adhoc-cli >= 0.1.4).
 #       * Claude Code CLI (único agente preinstalado) vía repo APT oficial.
 #       * ~/.local/bin en el PATH del usuario (npm global user-space).
 #   - Primer 'hola' / 'ad install adhoc-way' (con Tuqui authed por el dev):

--- a/roles/developer/tasks/adhoc_way.yml
+++ b/roles/developer/tasks/adhoc_way.yml
@@ -3,7 +3,7 @@
 #
 # Reparto de responsabilidades (decidido con DevOps, tarea Odoo #67663):
 #   - Playbook (acá, sin credenciales del dev):
-#       * Node/npm en el host (prerrequisito para el futuro 'ad install adhoc-way').
+#       * Node/npm en el host (prerrequisito de 'ad install adhoc-way', adhocCli >= v0.1.4).
 #       * Claude Code CLI (único agente preinstalado) vía repo APT oficial.
 #       * ~/.local/bin en el PATH del usuario (npm global user-space).
 #   - Primer 'hola' / 'ad install adhoc-way' (con Tuqui authed por el dev):


### PR DESCRIPTION
El comentario de cabecera de `roles/developer/tasks/adhoc_way.yml` describe `ad install adhoc-way` como "futuro". El subcomando ya está implementado en `adhocCli` (PR #13) y se distribuye por el APT repo desde el release `v0.1.4`, así que el prerrequisito Node/npm que deja este task ya tiene su consumidor real.

Cambio de una línea, solo comentario — no toca tasks, vars ni gates de perfil.

## Test plan

- `yamllint roles/developer/tasks/adhoc_way.yml` (línea de 92 chars, bajo el `max: 200` del repo).
- Sin cambio de comportamiento: el diff es un comentario.