### PR TITLE
feat: gestionar energía y salud de batería en el provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ Registro de cambios relevantes del proyecto. Formato basado en [Keep a Changelog
 
 ---
 
+## [2026-08-12]
+
+### Feature: gestión de energía y salud de batería
+
+- Nuevo bloque `Power` en los `pre_tasks` de `local.yml` (tag `power`), transversal a
+  todos los perfiles. No va en `funcional` porque `freelance_developer` corre un subset
+  con `tasks_from` y no lo heredaría
+- **Umbrales de carga 75/80%** vía `/usr/local/bin/adhoc-battery-thresholds` +
+  servicio `adhoc-battery-thresholds.service`, que los re-aplica en cada boot porque el
+  EC no los persiste. Configurables con `adhoc_battery_charge_start` /
+  `adhoc_battery_charge_stop`
+- **Fact local `ansible_local.battery`** (`/etc/ansible/facts.d/battery.fact`) con
+  `full`, `design`, `cycle_count` y `health_pct`, para tener salud de batería en el
+  inventario de la flota. El playbook avisa si la salud queda bajo
+  `adhoc_battery_health_warn` (80%)
+- **Solo si TLP ya está instalado:** fuerza `CPU_BOOST_ON_AC=1`. Sin eso, un `tlp bat`
+  deja el turbo boost apagado también en AC y la CPU queda clavada en el base clock
+- **Solo si el equipo no expone un `power_supply` tipo `Mains`** (carga por USB-C):
+  instala `tlp-powersource.timer`, que aplica el perfil TLP por polling cada 30s. Esas
+  máquinas no emiten uevents de `power_supply`, así que TLP nunca conmuta de perfil solo
+- No instala TLP ni toca `power-profiles-daemon`. Todo el bloque se auto-skipea en
+  equipos sin batería, así que no afecta desktops ni los contenedores de Molecule
+- Medido en un ThinkPad E14 Gen 4 (Ryzen 7 5825U): 31 W → 11.34 W de consumo, o sea de
+  55 min a 2 h 30 de autonomía
+
 ## [2026-06-27]
 
 ### Feature: preparación de terreno para adhoc-way (Claude Code + Node)

--- a/README.md
+++ b/README.md
@@ -221,6 +221,39 @@ ansible-playbook assign_laptop.yml \
 
 ---
 
+## 🔋 Energía y Batería
+
+El playbook configura esto solo, en cualquier perfil (tag `power`). Se saltea entero en
+equipos sin batería.
+
+- **Umbrales de carga 75/80%:** la batería deja de cargar al 80% y no reanuda hasta bajar
+  del 75%. Es deliberado — mantener una batería al 100% permanentemente la degrada mucho
+  más rápido. Si necesitás autonomía completa para un viaje:
+
+  ```bash
+  echo 100 | sudo tee /sys/class/power_supply/BAT0/charge_control_end_threshold
+  ```
+
+  Eso vuelve a 80 en el próximo boot. Para cambiarlo de forma permanente, pasale
+  `-e "adhoc_battery_charge_stop=100"` al playbook.
+
+- **Salud de la batería:** queda expuesta como fact de Ansible, consultable en cualquier
+  momento:
+
+  ```bash
+  sudo /etc/ansible/facts.d/battery.fact
+  # {"full": 35800000, "design": 45730000, "cycle_count": 504, "health_pct": 78.3}
+  ```
+
+  `health_pct` es la capacidad actual contra la de fábrica. Por debajo del 80% conviene
+  evaluar el reemplazo; el playbook lo avisa al correr.
+
+Si el equipo tiene **TLP** instalado (no lo instala el playbook), además se asegura de que
+el turbo boost se restaure al enchufar, y en equipos que cargan por USB-C se instala un
+timer que conmuta el perfil de TLP según la fuente de energía.
+
+---
+
 ## 🧪 Testing y Desarrollo
 
 Este proyecto utiliza **Molecule** con Docker para tests automatizados sobre
@@ -254,6 +287,11 @@ gpasswd -a tu_usuario sudo
 exit
 sudo reboot
 ```
+
+### La batería no carga más allá del 80%
+
+Es intencional, no es una falla. Ver [Energía y Batería](#-energía-y-batería) para el
+motivo y cómo subir el tope si necesitás autonomía completa.
 
 ### Error: Paquete no disponible en Debian 13
 

--- a/local.yml
+++ b/local.yml
@@ -5,6 +5,9 @@
 
   vars:
     target_profile: "{{ profile_override | default('funcional') }}"
+    adhoc_battery_charge_start: 75
+    adhoc_battery_charge_stop: 80
+    adhoc_battery_health_warn: 80
 
   # --- TAREAS PREVIAS ---
   pre_tasks:
@@ -45,6 +48,228 @@
         - name: Timezone | Asegurar que la sincronización NTP esté habilitada
           ansible.builtin.command: timedatectl set-ntp true
           changed_when: false
+
+    - name: Power | Salud de batería y umbrales de carga
+      tags: always, power
+      block:
+        - name: Power | Detectar si el equipo tiene batería
+          ansible.builtin.stat:
+            path: /sys/class/power_supply/BAT0
+          register: adhoc_battery
+
+        - name: Power | Configuración dependiente de batería
+          when: adhoc_battery.stat.exists
+          block:
+            - name: Power | Crear directorio de facts locales
+              ansible.builtin.file:
+                path: /etc/ansible/facts.d
+                state: directory
+                owner: root
+                group: root
+                mode: "0755"
+
+            - name: Power | Instalar fact de salud de batería
+              ansible.builtin.copy:
+                dest: /etc/ansible/facts.d/battery.fact
+                owner: root
+                group: root
+                mode: "0755"
+                content: |
+                  #!/bin/sh
+                  # Expone la salud de la batería como ansible_local.battery
+                  B=/sys/class/power_supply/BAT0
+                  [ -d "$B" ] || { echo '{}'; exit 0; }
+                  # Normaliza a 0 lo vacío o no numérico: sysfs puede devolver un
+                  # archivo vacío, y eso emitiría un JSON inválido
+                  read_num() {
+                    v=$(cat "$1" 2>/dev/null || cat "$2" 2>/dev/null)
+                    case "$v" in
+                      '' | *[!0-9]*) echo 0 ;;
+                      *) echo "$v" ;;
+                    esac
+                  }
+                  full=$(read_num "$B/energy_full" "$B/charge_full")
+                  design=$(read_num "$B/energy_full_design" "$B/charge_full_design")
+                  cycles=$(read_num "$B/cycle_count" /dev/null)
+                  health=0
+                  [ "$design" -gt 0 ] && health=$(awk "BEGIN{printf \"%.1f\", 100*$full/$design}")
+                  printf '{"full": %s, "design": %s, "cycle_count": %s, "health_pct": %s}\n' \
+                    "$full" "$design" "$cycles" "$health"
+
+            - name: Power | Recolectar los facts locales recién instalados
+              ansible.builtin.setup:
+                filter: ansible_local
+
+            - name: Power | Reportar salud de la batería
+              ansible.builtin.debug:
+                msg: >-
+                  Batería al {{ adhoc_bat.health_pct | default('n/d') }}% de su capacidad de fábrica,
+                  {{ adhoc_bat.cycle_count | default('n/d') }} ciclos.
+              vars:
+                adhoc_bat: "{{ ansible_local.battery | default({}) }}"
+
+            - name: Power | Avisar si la batería está degradada
+              ansible.builtin.debug:
+                msg: >-
+                  ATENCIÓN: batería al {{ ansible_local.battery.health_pct }}% con
+                  {{ ansible_local.battery.cycle_count }} ciclos. Evaluar reemplazo.
+              when:
+                - ansible_local.battery.health_pct is defined
+                - ansible_local.battery.health_pct | float < adhoc_battery_health_warn | float
+
+            - name: Power | Detectar si el equipo expone umbrales de carga
+              ansible.builtin.stat:
+                path: /sys/class/power_supply/BAT0/charge_control_end_threshold
+              register: adhoc_charge_threshold
+
+            - name: Power | Umbrales de carga persistentes
+              when: adhoc_charge_threshold.stat.exists
+              block:
+                - name: Power | Instalar el script de umbrales de carga
+                  ansible.builtin.copy:
+                    dest: /usr/local/bin/adhoc-battery-thresholds
+                    owner: root
+                    group: root
+                    mode: "0755"
+                    content: |
+                      #!/bin/sh
+                      # El start debe escribirse antes del stop: el EC valida start < stop
+                      for b in /sys/class/power_supply/BAT*; do
+                        [ -w "$b/charge_control_start_threshold" ] &&
+                          echo {{ adhoc_battery_charge_start }} > "$b/charge_control_start_threshold"
+                        [ -w "$b/charge_control_end_threshold" ] &&
+                          echo {{ adhoc_battery_charge_stop }} > "$b/charge_control_end_threshold"
+                      done
+                      exit 0
+                  register: adhoc_thresholds_script
+
+                - name: Power | Instalar el servicio de umbrales de carga
+                  ansible.builtin.copy:
+                    dest: /etc/systemd/system/adhoc-battery-thresholds.service
+                    owner: root
+                    group: root
+                    mode: "0644"
+                    content: |
+                      [Unit]
+                      Description=Umbrales de carga de bateria (Adhoc)
+                      After=multi-user.target
+
+                      [Service]
+                      Type=oneshot
+                      RemainAfterExit=yes
+                      ExecStart=/usr/local/bin/adhoc-battery-thresholds
+
+                      [Install]
+                      WantedBy=multi-user.target
+                  register: adhoc_thresholds_unit
+
+                - name: Power | Habilitar el servicio de umbrales de carga
+                  ansible.builtin.systemd:
+                    name: adhoc-battery-thresholds.service
+                    daemon_reload: true
+                    enabled: true
+                    state: started
+
+                - name: Power | Re-aplicar los umbrales si cambió la configuración
+                  ansible.builtin.systemd:
+                    name: adhoc-battery-thresholds.service
+                    state: restarted
+                  when: adhoc_thresholds_script is changed or adhoc_thresholds_unit is changed
+
+            - name: Power | Detectar si TLP está instalado
+              ansible.builtin.stat:
+                path: /etc/tlp.conf
+              register: adhoc_tlp_conf
+
+            - name: Power | Ajustes para equipos con TLP
+              when: adhoc_tlp_conf.stat.exists
+              block:
+                # Sin esto, un `tlp bat` deja el turbo apagado también en AC.
+                - name: Power | Asegurar que TLP restaure el turbo boost en AC
+                  ansible.builtin.lineinfile:
+                    path: /etc/tlp.conf
+                    regexp: '^#?\s*CPU_BOOST_ON_AC='
+                    line: CPU_BOOST_ON_AC=1
+                    state: present
+
+                # grep sale 1 si ningún device es Mains (equipos que cargan por USB-C):
+                # es el caso esperado y lo resuelve el `when` del bloque siguiente.
+                - name: Power | Detectar si el equipo expone una fuente AC (tipo Mains)
+                  ansible.builtin.shell: grep -lx Mains /sys/class/power_supply/*/type 2>/dev/null
+                  register: adhoc_ac_device
+                  changed_when: false
+                  failed_when: false
+
+                # Sin device Mains no hay uevents de power_supply: TLP nunca conmuta de perfil.
+                - name: Power | Conmutación de perfil TLP por polling
+                  when: adhoc_ac_device.stdout | trim == ''
+                  block:
+                    - name: Power | Instalar el chequeo de fuente de energía
+                      ansible.builtin.copy:
+                        dest: /usr/local/bin/tlp-powersource
+                        owner: root
+                        group: root
+                        mode: "0755"
+                        content: |
+                          #!/bin/sh
+                          S=/run/tlp-powersource.state
+                          case "$(cat /sys/class/power_supply/BAT0/status)" in
+                            Discharging) m=bat ;;
+                            *)           m=ac  ;;
+                          esac
+                          [ -r "$S" ] && [ "$(cat "$S")" = "$m" ] && exit 0
+                          printf '%s' "$m" > "$S"
+                          /usr/sbin/tlp auto
+
+                    - name: Power | Instalar unidades del chequeo de fuente
+                      ansible.builtin.copy:
+                        dest: "/etc/systemd/system/tlp-powersource.{{ item.ext }}"
+                        owner: root
+                        group: root
+                        mode: "0644"
+                        content: "{{ item.content }}"
+                      loop:
+                        - ext: service
+                          content: |
+                            [Unit]
+                            Description=Aplicar perfil TLP segun la fuente de energia
+
+                            [Service]
+                            Type=oneshot
+                            ExecStart=/usr/local/bin/tlp-powersource
+                        - ext: timer
+                          content: |
+                            [Unit]
+                            Description=Chequear la fuente de energia cada 30s
+
+                            [Timer]
+                            OnBootSec=30
+                            OnUnitActiveSec=30
+                            AccuracySec=5
+
+                            [Install]
+                            WantedBy=timers.target
+                      loop_control:
+                        label: "tlp-powersource.{{ item.ext }}"
+                      register: adhoc_powersource_units
+
+                    - name: Power | Habilitar el timer de fuente de energía
+                      ansible.builtin.systemd:
+                        name: tlp-powersource.timer
+                        daemon_reload: true
+                        enabled: true
+                        state: started
+
+                    - name: Power | Reiniciar el timer si cambiaron las unidades
+                      ansible.builtin.systemd:
+                        name: tlp-powersource.timer
+                        state: restarted
+                      when: adhoc_powersource_units is changed
+
+                    - name: Power | Quitar la regla udev obsoleta
+                      ansible.builtin.file:
+                        path: /etc/udev/rules.d/86-tlp-bat0.rules
+                        state: absent
 
   # --- SECCIÓN DE ROLES ---
   roles:

--- a/specifications.md
+++ b/specifications.md
@@ -142,6 +142,33 @@ no en READMEs por rol. NO agregar `roles/<rol>/README.md` ni guías por-perfil e
 `docs/`; si algo es relevante para usuarios va al `README.md`, y si es arquitectura o
 una regla de contribución, acá.
 
+### 3.7. Gestión de Energía (bloque `Power` de `local.yml`)
+
+Decisiones tomadas al sumar la gestión de energía, documentadas para no re-litigarlas:
+
+- **Vive en `pre_tasks` de `local.yml`, no en un rol ni en `funcional`.** Es transversal
+  a todos los perfiles, y `funcional` no alcanza porque `freelance_developer` corre un
+  subset con `tasks_from` sin heredarlo vía `meta`. Se evaluó un rol `power` propio y se
+  descartó: no hay superficie suficiente para justificar la estructura.
+- **Se aplica a la flota solo lo que tiene beneficio medido y riesgo bajo:** umbrales de
+  carga y fact de salud. Quedó deliberadamente **afuera**, como opt-in a decidir con IT:
+  instalar TLP (remueve `power-profiles-daemon` y con él el selector de perfiles de
+  GNOME), `CPU_BOOST_ON_BAT=0` (da ~14 W pero deja la CPU en el base clock a batería —
+  un costo de rendimiento que no se impone por default), `USB_AUTOSUSPEND` (rompe mouse
+  y headsets si no se arma un `USB_DENYLIST`) y el runtime PM de PCI/ASPM
+  (**medido: 0.16 W**, no justifica el riesgo de regresión en una flota).
+- **Los umbrales se re-aplican con un servicio en cada boot**, no con un `echo` one-shot:
+  el EC no los persiste entre reinicios en todos los modelos.
+- **El polling de TLP no es capricho.** En equipos que cargan por USB-C y no exponen un
+  `power_supply` de tipo `Mains`, el kernel no emite uevents de `power_supply`
+  (verificado con `udevadm monitor --subsystem-match=power_supply`), así que ni TLP ni
+  una regla udev propia detectan el cambio de fuente. El timer cada 30s es el único
+  mecanismo que funciona; el script compara contra un state file en `/run` para no
+  re-aplicar cuando no hubo transición.
+- **Molecule no cubre este bloque:** en Docker no existe `/sys/class/power_supply/BAT0`,
+  así que todo se auto-skipea, y tampoco hay escenario de Molecule para el playbook raíz.
+  La verificación fue manual contra el sysfs de un equipo real.
+
 ---
 
 ## 4. Testing Strategy (Molecule)


### PR DESCRIPTION
## Qué hace

Suma un bloque `Power` a los `pre_tasks` de `local.yml` (tag `power`), transversal a todos los perfiles. No va en `funcional` porque `freelance_developer` corre un subset con `tasks_from` y no lo heredaría vía `meta`.

Todo aplica por capas de detección, así que es seguro para hardware heterogéneo:

| Condición | Qué hace |
|---|---|
| Sin batería (desktop, contenedor de Molecule) | Se saltea entero |
| Con batería | Instala el fact `ansible_local.battery`, reporta salud y avisa bajo el 80% |
| Expone `charge_control_end_threshold` | Servicio systemd que aplica 75/80 en cada boot |
| Tiene TLP instalado | Fuerza `CPU_BOOST_ON_AC=1` |
| Tiene TLP **y** no expone `power_supply` tipo `Mains` | Instala `tlp-powersource.timer` (polling cada 30s) |

Los dos últimos casos vienen de problemas concretos encontrados al diagnosticar el consumo de un equipo real:

- Un `tlp bat` apaga el turbo boost (`CPU_BOOST_ON_BAT=0`, un default que vive en `/usr/share/tlp/defaults.conf` y no aparece en `/etc/tlp.conf`) y **no lo restaura al volver a AC** si `CPU_BOOST_ON_AC` no está explícito. Resultado: la máquina queda enchufada con la CPU clavada en el base clock — lo peor de los dos mundos. Detalle sutil: el atributo global `/sys/devices/system/cpu/cpufreq/boost` sigue reportando `1` mientras los per-policy están en `0`.
- En equipos que cargan por USB-C y no exponen un device `Mains`, el kernel **no emite uevents de `power_supply`** (verificado con `udevadm monitor --subsystem-match=power_supply`: cero eventos al desenchufar). Ni TLP ni una regla udev propia detectan el cambio de fuente, así que el polling es el único mecanismo que funciona.

## Qué NO hace, deliberadamente

Se aplica a la flota solo lo que tiene beneficio medido y riesgo bajo. Queda como opt-in a decidir con IT:

- **Instalar TLP** — remueve `power-profiles-daemon` y con él el selector de perfiles de GNOME.
- **`CPU_BOOST_ON_BAT=0`** — da ~14 W, pero deja la CPU en el base clock a batería. Es un costo de rendimiento que no se impone por default.
- **`USB_AUTOSUSPEND=1`** — rompe mouse y headsets si no se arma un `USB_DENYLIST`.
- **Runtime PM de PCI / ASPM** — **medido: 0.16 W**. No justifica el riesgo de regresión en una flota.

Decisiones documentadas en `specifications.md` §3.7 para no re-litigarlas.

## Impacto medido

En un ThinkPad E14 Gen 4 (Ryzen 7 5825U): **31 W → 11.34 W**, o sea de 55 min a 2 h 30 de autonomía. Desglose por causa: turbo boost 13.9 W, dock + monitor externo 4.0 W, brillo 1.8 W, runtime PM 0.16 W.

## Test plan

- [x] `yamllint` pasa
- [x] Los 3 scripts embebidos pasan `sh -n`
- [x] El fact contra un sysfs real devuelve JSON válido: `{"full": 35800000, "design": 45730000, "cycle_count": 504, "health_pct": 78.3}`
- [x] El fact probado en 6 casos borde (archivo vacío, faltante, `design=0`, no numérico, `charge_*` en vez de `energy_*`): todos JSON válido, stderr limpio
- [x] Idempotencia por inspección: `copy`/`file`/`lineinfile` son idempotentes, y los dos `state: restarted` están gateados con `when: ... is changed`
- [ ] `ansible-lint` — **no se pudo correr localmente** (el hook fija `language_version: python3.13` y el devcontainer trae 3.12). Se espera de este CI
- [ ] `markdownlint` — **no se pudo correr localmente** (falta `libatomic.so.1` para su node). Se espera de este CI

## Review previo

Dos hallazgos propios, ambos corregidos en este mismo commit:

1. **Correctness:** el fact emitía JSON inválido si un archivo de sysfs existe pero está vacío (`cat` sale 0, el fallback `|| echo 0` no dispara). Se agregó un helper `read_num` que normaliza vacío y no-numérico a 0.
2. **Convergencia:** la task que habilitaba `adhoc-battery-thresholds.service` tenía `when: ... is changed`, así que en corridas siguientes no verificaba `enabled: true`. Se separó en habilitar (siempre) + restart (solo si cambió), como ya estaba el timer.

## Nota sobre cobertura de Molecule

Este bloque **no queda cubierto por Molecule**: no hay escenario para el playbook raíz (solo por rol), y en Docker no existe `/sys/class/power_supply/BAT0`, así que se auto-skipearía igual. La verificación fue manual contra el sysfs de un equipo real y está documentada en §3.7.